### PR TITLE
CSI: Make attach mandatory in ceph CSIDriver object

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -263,7 +263,6 @@ below, which you should change to match where your images are located.
         value: "quay.io/k8scsi/csi-provisioner:v1.3.0"
     - name: ROOK_CSI_SNAPSHOTTER_IMAGE
         value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
-    #ROOK_CSI_ATTACHER_IMAGE is required if Kubernetes version is 1.13.x
     - name: ROOK_CSI_ATTACHER_IMAGE
         value: "quay.io/k8scsi/csi-attacher:v1.2.0"
 ```

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -86,7 +86,6 @@ csi:
     #image: quay.io/k8scsi/csi-provisioner:v1.3.0
   #snapshotter:
     #image: quay.io/k8scsi/csi-snapshotter:v1.2.0
-  # attacher is required if Kubernetes version is 1.13.x
   #attacher:
     #image: quay.io/k8scsi/csi-attacher:v1.2.0
 

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -16,6 +16,22 @@ spec:
     spec:
       serviceAccount: rook-csi-cephfs-provisioner-sa
       containers:
+        - name: csi-attacher
+          image: {{ .AttacherImage }}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election=true"
+            - "--timeout=150s"
+            - "--leader-election-type=leases"
+            - "--leader-election-namespace={{ .Namespace }}"
+          env:
+            - name: ADDRESS
+              value: /csi/csi-provisioner.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-provisioner
           image: {{ .ProvisionerImage }}
           args:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -33,6 +33,22 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-rbdplugin-attacher
+          image: {{ .AttacherImage }}
+          args:
+            - "--v=5"
+            - "--timeout=150s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election=true"
+            - "--leader-election-type=leases"
+            - "--leader-election-namespace={{ .Namespace }}"
+          env:
+            - name: ADDRESS
+              value: /csi/csi-provisioner.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-snapshotter
           image:  {{ .SnapshotterImage }}
           args:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -179,7 +179,6 @@ spec:
         #  value: "quay.io/k8scsi/csi-provisioner:v1.3.0"
         #- name: ROOK_CSI_SNAPSHOTTER_IMAGE
         #  value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
-        # ROOK_CSI_ATTACHER_IMAGE is required if Kubernetes version is 1.13.x
         #- name: ROOK_CSI_ATTACHER_IMAGE
         #  value: "quay.io/k8scsi/csi-attacher:v1.2.0"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -324,7 +324,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 
 // createCSIDriverInfo Registers CSI driver by creating a CSIDriver object
 func createCSIDriverInfo(clientset kubernetes.Interface, name string) error {
-	attach := false
+	attach := true
 	mountInfo := false
 	// Create CSIDriver object
 	csiDriver := &k8scsi.CSIDriver{


### PR DESCRIPTION
A recent PR #4172 added the ability for rook to create
the CSIDriver object on a kubernetes cluster. The change also
made it so that attachRequired value in the ceph CSI drivers
were set to false.

This leads to the entire attach skipping the AD controller
that deals with RWO attachment enforcement. Thus, if a
CephFS volume is marked RWO, 2 pods on different hosts can
end up mounting the same and consuming it at the same time.

Further for RBD, currently the image watchers are the only ones
that prevent a double mount of an image, other than the AD controller
enforcement of single attach for RWO RBD PVs. This has proven
not to be reliable in the face of MON failures, as the watcher
information is lost, and a second mount is allowed.

Thus, we need to bring back the attach requirement to leverage
kubernetes checks and balances for RWO volume type, and
prevent unwanted multi-attach use of the same.

This PR hence undoes some of the changes introduced by the
PR #4172, to bring the attacher side car back, and also declare
the attachRequired for both RBD and CephFS CSI plugins as true.

NOTE: Initially the attachRequired was set to false as this
improved attach times considerably on kubernetes, as the
entire phase was being avoided.

Signed-off-by: ShyamsundarR <srangana@redhat.com>
(cherry picked from commit 48a0decc49feedef358b658bee613ddc66e6a6e7)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
