### PR TITLE
ceph: rgw change the liveness probe url

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -128,7 +128,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 		LivenessProbe: &v1.Probe{
 			Handler: v1.Handler{
 				HTTPGet: &v1.HTTPGetAction{
-					Path: "/",
+					Path: "/swift/healthcheck",
 					Port: intstr.FromInt(int(c.store.Spec.Gateway.Port)),
 				},
 			},


### PR DESCRIPTION
to the RGWs swift objectstorage healthcheck api url [1]
which resolves an OCS false-positive CLBO of the RGW pod.

[1] https://docs.openstack.org/swift/latest/middleware.html#healthcheck

Signed-off-by: Mark Kogan <mkogan@redhat.com>
(cherry picked from commit 3c807688fe6a5fe5ce342221a77aac9a955bfe98)

For https://bugzilla.redhat.com/show_bug.cgi?id=1768874