### PR TITLE
ceph: only set isUpgrade when the image changes

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -375,7 +375,7 @@ func (c *cluster) checkSetOrchestrationStatus() bool {
 }
 
 // This function compare the Ceph spec image and the cluster running version
-// It returns false if the image is different and true if identical
+// It returns true if the image is different and false if identical
 func diffImageSpecAndClusterRunningVersion(imageSpecVersion cephver.CephVersion, runningVersions client.CephDaemonsVersions) (bool, error) {
 	numberOfCephVersions := len(runningVersions.Overall)
 	if numberOfCephVersions == 0 {
@@ -399,10 +399,9 @@ func diffImageSpecAndClusterRunningVersion(imageSpecVersion cephver.CephVersion,
 			clusterRunningVersion := *version
 
 			// If this is the same version
-			// We return 'true' so that we restart using the Ceph checks
 			if cephver.IsIdentical(clusterRunningVersion, imageSpecVersion) {
 				logger.Debugf("both cluster and image spec versions are identical, doing nothing %s", imageSpecVersion.String())
-				return true, nil
+				return false, nil
 			}
 
 			if cephver.IsSuperior(imageSpecVersion, clusterRunningVersion) {

--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -109,7 +109,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 
 	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions5)
 	assert.NoError(t, err)
-	assert.True(t, m)
+	assert.False(t, m)
 }
 
 func TestMinVersion(t *testing.T) {

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -607,6 +607,7 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 	// Also we make sure there is actually an upgrade to perform
 	// It's not because the image spec changed that the ceph version did
 	// Someone could use the same Ceph version but with a different base OS content
+	cluster.isUpgrade = false
 	if versionChanged {
 		// we compare against cluster.Info.CephVersion since it received the new spec version earlier
 		// so don't get confused by the name of the function and its arguments
@@ -628,9 +629,9 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 					return
 				}
 			}
-			// If Ceph is healthy let's start the upgrade!
-			cluster.isUpgrade = true
 		}
+		// If Ceph is healthy let's start the upgrade!
+		cluster.isUpgrade = true
 	} else {
 		logger.Infof("ceph daemons running versions are: %+v", runningVersions)
 	}


### PR DESCRIPTION
The isUpgrade flag was being set every time the operator
was started. This caused the upgrade checks to be run every
time the operator restarted. Thus, if any mons were down,
you likely would get stuck on the upgrade checks since another
mon could not be stopped. We need to rely on the upgrade being
detected either by a different image name from the cluster CR
update, or from different versions of the daemons running
in case the operator was restarted in the middle of an upgrade.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit b79c223986cd94899be273cb7a66de1a5e7518a2)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
