### PR TITLE
Enable Ceph-CSI 2.0 by default

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -22,9 +22,6 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election=true"
-            {{ if .SetAttacherLeaderElectionType }}
-            - "--leader-election-type=leases"
-            {{ end }}
             - "--timeout=150s"
             - "--leader-election-namespace={{ .Namespace }}"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -34,7 +34,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        {{ if .EnableResizer }}
         - name: csi-resizer
           image: {{ .ResizerImage }}
           args:
@@ -50,7 +49,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        {{ end }}
         - name: csi-provisioner
           image: {{ .ProvisionerImage }}
           args:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -33,7 +33,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        {{ if .EnableResizer }}
         - name: csi-resizer
           image: {{ .ResizerImage }}
           args:
@@ -49,7 +48,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        {{ end }}
         - name: csi-rbdplugin-attacher
           image: {{ .AttacherImage }}
           args:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -55,9 +55,6 @@ spec:
             - "--timeout=150s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election=true"
-            {{ if .SetAttacherLeaderElectionType }}
-            - "--leader-election-type=leases"
-            {{ end }}
             - "--leader-election-namespace={{ .Namespace }}"
           env:
             - name: ADDRESS

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -48,7 +48,6 @@ type Param struct {
 	ForceCephFSKernelClient       string
 	CephFSPluginUpdateStrategy    string
 	RBDPluginUpdateStrategy       string
-	EnableResizer                 bool
 	SetAttacherLeaderElectionType bool
 	CephFSGRPCMetricsPort         uint16
 	CephFSLivenessMetricsPort     uint16
@@ -93,7 +92,7 @@ var (
 // manually challenging.
 var (
 	// image names
-	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v1.2.2"
+	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v2.0.0"
 	DefaultRegistrarImage   = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
 	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.4.0"
 	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v1.2.0"
@@ -227,14 +226,6 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if len(attacher) > 1 {
 		if strings.HasPrefix(attacher[1], "v1.2.") {
 			tp.SetAttacherLeaderElectionType = true
-		}
-	}
-
-	csiPluginImage := strings.Split(CSIParam.CSIPluginImage, ":")
-	// as ceph-csi v2.x.x support resizer, enable it
-	if len(csiPluginImage) > 1 {
-		if strings.HasPrefix(csiPluginImage[1], "v2.") {
-			tp.EnableResizer = true
 		}
 	}
 

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -35,24 +35,23 @@ import (
 )
 
 type Param struct {
-	CSIPluginImage                string
-	RegistrarImage                string
-	ProvisionerImage              string
-	AttacherImage                 string
-	SnapshotterImage              string
-	ResizerImage                  string
-	DriverNamePrefix              string
-	EnableSnapshotter             string
-	EnableCSIGRPCMetrics          string
-	KubeletDirPath                string
-	ForceCephFSKernelClient       string
-	CephFSPluginUpdateStrategy    string
-	RBDPluginUpdateStrategy       string
-	SetAttacherLeaderElectionType bool
-	CephFSGRPCMetricsPort         uint16
-	CephFSLivenessMetricsPort     uint16
-	RBDGRPCMetricsPort            uint16
-	RBDLivenessMetricsPort        uint16
+	CSIPluginImage             string
+	RegistrarImage             string
+	ProvisionerImage           string
+	AttacherImage              string
+	SnapshotterImage           string
+	ResizerImage               string
+	DriverNamePrefix           string
+	EnableSnapshotter          string
+	EnableCSIGRPCMetrics       string
+	KubeletDirPath             string
+	ForceCephFSKernelClient    string
+	CephFSPluginUpdateStrategy string
+	RBDPluginUpdateStrategy    string
+	CephFSGRPCMetricsPort      uint16
+	CephFSLivenessMetricsPort  uint16
+	RBDGRPCMetricsPort         uint16
+	RBDLivenessMetricsPort     uint16
 }
 
 type templateParam struct {
@@ -95,7 +94,7 @@ var (
 	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v2.0.0"
 	DefaultRegistrarImage   = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
 	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.4.0"
-	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v1.2.0"
+	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v2.1.0"
 	DefaultSnapshotterImage = "quay.io/k8scsi/csi-snapshotter:v1.2.2"
 	defaultResizerImage     = "quay.io/k8scsi/csi-resizer:v0.4.0"
 )
@@ -218,17 +217,6 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	} else {
 		tp.ForceCephFSKernelClient = "true"
 	}
-
-	// "--leader-election-type=leases" parameter in external-attacher is
-	// removed in v2.1.0 but it is required if the external-attacher version is
-	// v1.2.x
-	attacher := strings.Split(CSIParam.AttacherImage, ":")
-	if len(attacher) > 1 {
-		if strings.HasPrefix(attacher[1], "v1.2.") {
-			tp.SetAttacherLeaderElectionType = true
-		}
-	}
-
 	// parse GRPC and Liveness ports
 	tp.CephFSGRPCMetricsPort = getPortFromENV("CSI_CEPHFS_GRPC_METRICS_PORT", DefaultCephFSGRPCMerticsPort)
 	tp.CephFSLivenessMetricsPort = getPortFromENV("CSI_CEPHFS_LIVENESS_METRICS_PORT", DefaultCephFSLivenessMerticsPort)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Downstream we want to enable the Ceph-CSI 2.0 driver by default. This PR reverts the commits that had made this not be the default upstream in the release-1.2 branch. This is done to simplify keeping the `release-1.2` and `ocs-4.3` branches in sync.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
