### PR TITLE
Bug: 1821219 Allow toolbox script to skip watching mons

### DIFF
--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -73,4 +73,6 @@ EOF
 write_endpoints
 
 # continuously update the mon endpoints if they fail over
-watch_endpoints
+if [ "$1" != "--skip-watch" ]; then
+  watch_endpoints
+fi


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The toolbox script is used for configuring the toolbox. If the mons are to fail over while the toolbox is running, the new list of mons needs to be updated. However, if run temporarily as a one-time job, the script only needs to initialize the ceph.conf and then exit.

**Which issue is resolved by this Pull Request:**
Related to BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1821219

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
