### PR TITLE
1830015: Restart portable osd pod if stuck

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -111,7 +111,7 @@ type ClusterController struct {
 	removeClusterCallbacks []func() error
 	csiConfigMutex         *sync.Mutex
 	nodeStore              cache.Store
-	osdChecker             *osd.Monitor
+	osdChecker             *osd.OSDHealthMonitor
 }
 
 // NewClusterController create controller for watching cluster custom resources created
@@ -481,7 +481,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 
 	if !cluster.Spec.External.Enable {
 		// Start the osd health checker only if running OSDs in the local ceph cluster
-		c.osdChecker = osd.NewMonitor(c.context, cluster.Namespace, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Info.CephVersion)
+		c.osdChecker = osd.NewOSDHealthMonitor(c.context, cluster.Namespace, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Info.CephVersion)
 		go c.osdChecker.Start(cluster.stopCh)
 	}
 

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -18,6 +18,7 @@ package osd
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -25,12 +26,14 @@ import (
 	testexec "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOSDStatus(t *testing.T) {
+func TestOSDHealthCheck(t *testing.T) {
 	cluster := "fake"
 
 	var execCount = 0
@@ -89,10 +92,10 @@ func TestOSDStatus(t *testing.T) {
 	}
 
 	// Initializing an OSD monitoring
-	osdMon := NewMonitor(context, cluster, true, cephVersion)
+	osdMon := NewOSDHealthMonitor(context, cluster, true, cephVersion)
 
 	// Run OSD monitoring routine
-	err := osdMon.osdStatus()
+	err := osdMon.checkOSDHealth()
 	assert.Nil(t, err)
 	// After creating an OSD, the dump has 1 mocked cmd and safe to destroy has 1 mocked cmd
 	assert.Equal(t, 2, execCount)
@@ -108,8 +111,70 @@ func TestMonitorStart(t *testing.T) {
 	}
 
 	stopCh := make(chan struct{})
-	osdMon := NewMonitor(&clusterd.Context{}, "cluster", true, cephVersion)
+	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, "cluster", true, cephVersion)
 	logger.Infof("starting osd monitor")
 	go osdMon.Start(stopCh)
 	close(stopCh)
+}
+
+func TestOSDRestartIfStuck(t *testing.T) {
+	clientset := testexec.New(1)
+	namespace := "test"
+	// Setting up objects needed to create OSD
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "osd0",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"ceph-osd-id": "23",
+				"portable":    "true",
+			},
+		},
+	}
+	pod.Spec.NodeName = "node0"
+	_, err := context.Clientset.CoreV1().Pods(namespace).Create(pod)
+	assert.NoError(t, err)
+
+	m := NewOSDHealthMonitor(context, namespace, false, cephver.CephVersion{})
+
+	podList := &v1.PodList{Items: []v1.Pod{*pod}}
+	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+
+	// The pod should still exist since it wasn't in a deleted state
+	p, err := context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+
+	// Add a deletion timestamp to the pod
+	pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	_, err = context.Clientset.CoreV1().Pods(namespace).Update(pod)
+	assert.NoError(t, err)
+
+	podList = &v1.PodList{Items: []v1.Pod{*pod}}
+	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+
+	// The pod should still exist since the node is ready
+	p, err = context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+
+	// Set the node to a not ready state
+	nodes, err := context.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	for _, node := range nodes.Items {
+		node.Status.Conditions[0].Status = v1.ConditionFalse
+		_, err := context.Clientset.CoreV1().Nodes().Update(&node)
+		assert.NoError(t, err)
+	}
+
+	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+
+	// The pod should be deleted since the pod is marked as deleted and the node is not ready
+	_, err = context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the OSD pod is portable and is on a failed node, the node will be stuck indefinitely in the terminating state. The pod can be force deleted in this scenario in order to allow the underlying volume to be detached and then mounted on another node.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1830015

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
