### PR TITLE
Bug 1830015: delete terminating osd pods even if not out

### DIFF
--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -47,7 +47,7 @@ func TestOSDHealthCheck(t *testing.T) {
 		execCount++
 		if args[1] == "dump" {
 			// Mock executor for OSD Dump command, returning an osd in Down state
-			return `{"OSDs": [{"OSD": 0, "Up": 1, "In": 0}]}`, nil
+			return `{"OSDs": [{"OSD": 0, "Up": 0, "In": 0}]}`, nil
 		} else if args[1] == "safe-to-destroy" {
 			// Mock executor for OSD Dump command, returning an osd in Down state
 			return `{"safe_to_destroy":[0],"active":[],"missing_stats":[],"stored_pgs":[]}`, nil


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When an OSD pod is stuck in terminating state, there is no need to check if the OSD is marked as out before force deleting. As long as the osd is down we will force delete the pod.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit 3c6bae56b70df9ef440936dde253f379f9ae2ea5)

**Which issue is resolved by this Pull Request:**
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1830015

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
