### PR TITLE
Bug 1833082: OSD on PVC node selector needs to be the deployment node selector

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -672,7 +672,8 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 				portable:            volumeSource.Portable,
 				tuneSlowDeviceClass: volumeSource.TuneSlowDeviceClass,
 			}
-			// If OSD isn't portable, we're getting the host name of the pod where the osd prepare job pod prepared the OSD.
+			// If OSD isn't portable, we're getting the host name either from the osd deployment that was already initialized
+			// or from the osd prepare job from initial creation.
 			if !volumeSource.Portable {
 				var err error
 				osdProps.crushHostname, err = c.getPVCHostName(pvcName)
@@ -686,21 +687,46 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 	return osdProperties{}, errors.Errorf("no valid VolumeSource found for pvc %s", pvcName)
 }
 
+// getPVCHostName finds the node where an OSD pod should be assigned with a node selector.
+// First look for the node selector that was previously used for the OSD, or if a new OSD
+// check for the assignment of the OSD prepare job.
 func (c *Cluster) getPVCHostName(pvcName string) (string, error) {
 	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", OSDOverPVCLabelKey, pvcName)}
-	podList, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(listOpts)
+
+	// Check for the existence of the OSD deployment where the node selector was applied
+	// in a previous reconcile.
+	deployments, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).List(listOpts)
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "failed to get deployment for osd with pvc %q", pvcName)
 	}
-	for _, pod := range podList.Items {
+	for _, d := range deployments.Items {
+		selectors := d.Spec.Template.Spec.NodeSelector
+		for label, value := range selectors {
+			if label == v1.LabelHostname {
+				return value, nil
+			}
+		}
+	}
+
+	// Since the deployment wasn't found it must be a new deployment so look at the node
+	// assignment of the OSD prepare pod
+	pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(listOpts)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get pod for osd with pvc %q", pvcName)
+	}
+	for _, pod := range pods.Items {
 		name, err := k8sutil.GetNodeHostName(c.context.Clientset, pod.Spec.NodeName)
 		if err != nil {
 			logger.Warningf("falling back to node name %s since hostname not found for node", pod.Spec.NodeName)
 			name = pod.Spec.NodeName
 		}
+		if name == "" {
+			return "", errors.Errorf("node name not found on the osd pod %q", pod.Name)
+		}
 		return name, nil
 	}
-	return "", err
+
+	return "", errors.Errorf("node selector not found on deployment for osd with pvc %q", pvcName)
 }
 
 func (c *Cluster) getOSDInfo(d *apps.Deployment) ([]OSDInfo, error) {

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -379,6 +379,55 @@ func TestAddNodeFailure(t *testing.T) {
 	assert.NotNil(t, startErr)
 }
 
+func TestGetPVCHostName(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	c := &Cluster{context: &clusterd.Context{Clientset: clientset}, Namespace: "ns"}
+	pvcName := "test-pvc"
+
+	// fail to get the host name when there is no pod or deployment
+	name, err := c.getPVCHostName(pvcName)
+	assert.Error(t, err)
+	assert.Equal(t, "", name)
+
+	// Create a sample osd deployment
+	osdDeployment := &apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "osd-23",
+			Namespace: c.Namespace,
+			Labels:    c.getOSDLabels(23, "", true),
+		},
+	}
+	k8sutil.AddLabelToDeployment(OSDOverPVCLabelKey, pvcName, osdDeployment)
+	osdDeployment.Spec.Template.Spec.NodeSelector = map[string]string{v1.LabelHostname: "testnode"}
+
+	_, err = clientset.AppsV1().Deployments(c.Namespace).Create(osdDeployment)
+	assert.NoError(t, err)
+
+	// get the host name based on the deployment
+	name, err = c.getPVCHostName(pvcName)
+	assert.NoError(t, err)
+	assert.Equal(t, "testnode", name)
+
+	// delete the deployment and get the host name based on the pod
+	err = clientset.AppsV1().Deployments(c.Namespace).Delete(osdDeployment.Name, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	osdPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "osd-23",
+			Namespace: c.Namespace,
+			Labels:    c.getOSDLabels(23, "", true),
+		},
+	}
+	osdPod.Labels = map[string]string{OSDOverPVCLabelKey: pvcName}
+	osdPod.Spec.NodeName = "testnode"
+	_, err = clientset.CoreV1().Pods(c.Namespace).Create(osdPod)
+	assert.NoError(t, err)
+
+	name, err = c.getPVCHostName(pvcName)
+	assert.NoError(t, err)
+	assert.Equal(t, "testnode", name)
+}
+
 func TestGetOSDInfo(t *testing.T) {
 	c := New(&cephconfig.ClusterInfo{}, &clusterd.Context{}, "ns", "myversion", cephv1.CephVersionSpec{},
 		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{},

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -519,7 +519,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	}
 	if osdProps.pvc.ClaimName != "" {
 		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, c.getPVCInitContainer(osdProps.pvc))
-		k8sutil.AddLabelToDeployement(OSDOverPVCLabelKey, osdProps.pvc.ClaimName, deployment)
+		k8sutil.AddLabelToDeployment(OSDOverPVCLabelKey, osdProps.pvc.ClaimName, deployment)
 		k8sutil.AddLabelToPod(OSDOverPVCLabelKey, osdProps.pvc.ClaimName, &deployment.Spec.Template)
 	}
 	if !osdProps.portable {

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -192,7 +192,7 @@ func AddRookVersionLabelToObjectMeta(meta *metav1.ObjectMeta) {
 	addRookVersionLabel(meta.Labels)
 }
 
-func AddLabelToDeployement(key, value string, d *v1.Deployment) {
+func AddLabelToDeployment(key, value string, d *v1.Deployment) {
 	if d == nil {
 		return
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
An OSD on a PVC when portable=false is assigned to a node with a node selector. The same node assignment is expected for the lifetime of the cluster. On subsequent reconciles, the operator was looking up the node assignment from the nodeName on the pod spec, which is not set if the pod is down. The operator needs to retrieve the assignment from the deployment spec node selector.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1833082

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
