### PR TITLE
Bug 1833038: Remove invalid verbose params from lv activate

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -67,12 +67,12 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 		go handleTerminate(context, lvPath, volumeGroupName)
 
 		// It's fine to continue if deactivate fails since we will return error if activate fails
-		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-anvv", volumeGroupName); err != nil {
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-an", volumeGroupName); err != nil {
 			logger.Errorf("failed to deactivate volume group for lv %q. output: %s. %v", lvPath, op, err)
 			return nil
 		}
 
-		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-ayvv", volumeGroupName); err != nil {
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-ay", volumeGroupName); err != nil {
 			return errors.Wrapf(err, "failed to activate volume group for lv %q. output: %s", lvPath, op)
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The activation of the lvs for OSDs had an invalid argument to vgchange. The invalid argument is now reverted to enable the OSDs in this scenario again.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit af54349a5ef245bdf54bb85dd818be12a4faf426)

**Which issue is resolved by this Pull Request:**
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1833038

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
