### PR TITLE
Bug 1838787: Revert verbose args for the LV release

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -475,7 +475,7 @@ func getActiveDirs(currentDirList []string, savedDirMap map[string]int, configDi
 
 // releaseLVMDevice deactivates the LV to release the device.
 func releaseLVMDevice(context *clusterd.Context, volumeGroupName string) error {
-	if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "lvchange", "-anvv", volumeGroupName); err != nil {
+	if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "lvchange", "-an", volumeGroupName); err != nil {
 		return errors.Wrapf(err, "failed to deactivate LVM %s. output: %s", volumeGroupName, op)
 	}
 	logger.Info("successfully released device from lvm")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The verbose args recently added are causing the lv release to fail and then causing the OSD to intermittently fail starting.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit 9e78faaa2cccbd68b3c46669534a3b7258b49bf4)

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1838787

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
