### PR TITLE
Bug 1848184: Handle node failure more gracefully (bp to release-4.4)

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -38,6 +38,7 @@ import (
 	discoverDaemon "github.com/rook/rook/pkg/daemon/discover"
 	cephclient "github.com/rook/rook/pkg/operator/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
@@ -421,7 +422,18 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 		}
 	}
 
+	monitoringActivated := false
 	if !cluster.Spec.External.Enable {
+		// If the local cluster has already been configured, immediately start monitoring the cluster.
+		// Test if the cluster has already been configured if the mgr deployment has been created.
+		// If the mgr does not exist, the mons have never been verified to be in quorum.
+		opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8sutil.AppAttr, mgr.AppName)}
+		mgrDeployments, err := c.context.Clientset.AppsV1().Deployments(cluster.Namespace).List(opts)
+		if err == nil && len(mgrDeployments.Items) > 0 {
+			c.startClusterMonitoring(cluster)
+			monitoringActivated = true
+		}
+
 		if err := c.configureLocalCephCluster(clusterObj.Namespace, clusterObj.Name, cluster, clusterObj); err != nil {
 			logger.Errorf("failed to configure local ceph cluster. %v", err)
 			return
@@ -432,6 +444,31 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 			return
 		}
 	}
+
+	// add the finalizer to the crd
+	err := c.addFinalizer(clusterObj.Namespace, clusterObj.Name)
+	if err != nil {
+		logger.Errorf("failed to add finalizer to cluster crd. %v", err)
+	}
+
+	if !monitoringActivated {
+		c.startClusterMonitoring(cluster)
+	}
+}
+
+func (c *ClusterController) startClusterMonitoring(cluster *cluster) {
+	if cluster.Info == nil {
+		clusterInfo, _, _, err := mon.CreateOrLoadClusterInfo(c.context, cluster.Namespace, nil)
+		if err != nil {
+			logger.Errorf("failed to start osd monitoring. %v", err)
+			return
+		}
+		cluster.Info = clusterInfo
+		logger.Infof("cluster info loaded for monitoring: %+v", clusterInfo)
+	}
+
+	// enable the cluster monitoring goroutines once
+	logger.Infof("enabling cluster monitoring goroutines")
 
 	// Start client CRD watcher
 	clientController := cephclient.NewClientController(c.context, cluster.Namespace)
@@ -471,9 +508,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	}
 
 	// Populate ClusterInfo
-	if cluster.Spec.External.Enable {
-		cluster.mons.ClusterInfo = cluster.Info
-	}
+	cluster.mons.ClusterInfo = cluster.Info
 
 	// Start mon health checker
 	healthChecker := mon.NewHealthChecker(cluster.mons, cluster.Spec)
@@ -486,14 +521,8 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	}
 
 	// Start the ceph status checker
-	cephChecker := newCephStatusChecker(c.context, cluster.Namespace, clusterObj.Name)
+	cephChecker := newCephStatusChecker(c.context, cluster.Namespace, cluster.crdName)
 	go cephChecker.checkCephStatus(cluster.stopCh)
-
-	// add the finalizer to the crd
-	err := c.addFinalizer(clusterObj.Namespace, clusterObj.Name)
-	if err != nil {
-		logger.Errorf("failed to add finalizer to cluster crd. %v", err)
-	}
 }
 
 // ************************************************************************************************

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mon
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephutil "github.com/rook/rook/pkg/daemon/ceph/util"
 	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -116,11 +118,13 @@ func (c *Cluster) checkHealth() error {
 			// when the mon isn't in the clusterInfo, but is in quorum and there are
 			// enough mons, remove it else remove it on the next run
 			if inQuorum && len(quorumStatus.MonMap.Mons) > desiredMonCount {
-				logger.Warningf("mon %s not in source of truth but in quorum, removing", mon.Name)
-				c.removeMon(mon.Name)
+				logger.Warningf("mon %q not in source of truth but in quorum, removing", mon.Name)
+				if err := c.removeMon(mon.Name); err != nil {
+					logger.Warningf("failed to remove mon %q. %v", mon.Name, err)
+				}
 			} else {
 				logger.Warningf(
-					"mon %s not in source of truth and not in quorum, not enough mons to remove now (wanted: %d, current: %d)",
+					"mon %q not in source of truth and not in quorum, not enough mons to remove now (wanted: %d, current: %d)",
 					mon.Name,
 					desiredMonCount,
 					len(quorumStatus.MonMap.Mons),
@@ -129,38 +133,42 @@ func (c *Cluster) checkHealth() error {
 		}
 
 		if inQuorum {
-			logger.Debugf("mon %s found in quorum", mon.Name)
+			logger.Debugf("mon %q found in quorum", mon.Name)
 			// delete the "timeout" for a mon if the pod is in quorum again
 			if _, ok := c.monTimeoutList[mon.Name]; ok {
 				delete(c.monTimeoutList, mon.Name)
-				logger.Infof("mon %s is back in quorum, removed from mon out timeout list", mon.Name)
+				logger.Infof("mon %q is back in quorum, removed from mon out timeout list", mon.Name)
 			}
-		} else {
-			logger.Debugf("mon %s NOT found in quorum. Mon quorum status: %+v", mon.Name, quorumStatus)
-			allMonsInQuorum = false
-
-			// If not yet set, add the current time, for the timeout
-			// calculation, to the list
-			if _, ok := c.monTimeoutList[mon.Name]; !ok {
-				c.monTimeoutList[mon.Name] = time.Now()
-			}
-
-			// when the timeout for the mon has been reached, continue to the
-			// normal failover/delete mon pod part of the code
-			if time.Since(c.monTimeoutList[mon.Name]) <= MonOutTimeout {
-				timeToFailover := int(MonOutTimeout.Seconds() - time.Since(c.monTimeoutList[mon.Name]).Seconds())
-				logger.Warningf("mon %s not found in quorum, waiting for timeout (%d seconds left) before failover", mon.Name, timeToFailover)
-				continue
-			}
-
-			logger.Warningf("mon %s NOT found in quorum and timeout exceeded, mon will be failed over", mon.Name)
-			c.failMon(len(quorumStatus.MonMap.Mons), desiredMonCount, mon.Name)
-			// only deal with one unhealthy mon per health check
-			return nil
+			continue
 		}
+
+		logger.Debugf("mon %q NOT found in quorum. Mon quorum status: %+v", mon.Name, quorumStatus)
+		allMonsInQuorum = false
+
+		// If not yet set, add the current time, for the timeout
+		// calculation, to the list
+		if _, ok := c.monTimeoutList[mon.Name]; !ok {
+			c.monTimeoutList[mon.Name] = time.Now()
+		}
+
+		// when the timeout for the mon has been reached, continue to the
+		// normal failover/delete mon pod part of the code
+		if time.Since(c.monTimeoutList[mon.Name]) <= MonOutTimeout {
+			timeToFailover := int(MonOutTimeout.Seconds() - time.Since(c.monTimeoutList[mon.Name]).Seconds())
+			logger.Warningf("mon %q not found in quorum, waiting for timeout (%d seconds left) before failover", mon.Name, timeToFailover)
+
+			// Restart the mon if it is stuck on a failed node
+			c.restartMonIfStuckTerminating(mon.Name)
+			continue
+		}
+
+		logger.Warningf("mon %q NOT found in quorum and timeout exceeded, mon will be failed over", mon.Name)
+		c.failMon(len(quorumStatus.MonMap.Mons), desiredMonCount, mon.Name)
+		// only deal with one unhealthy mon per health check
+		return nil
 	}
 
-	// after all unhealthy mons have been removed/failovered
+	// after all unhealthy mons have been removed or failed over
 	// handle all mons that haven't been in the Ceph mon map
 	for mon := range monsNotFound {
 		logger.Warningf("mon %s NOT found in ceph mon map, failover", mon)
@@ -402,4 +410,22 @@ func (c *Cluster) addOrRemoveExternalMonitor(status client.MonStatusResponse) (b
 
 	logger.Debugf("ClusterInfo.Monitors is %+v", c.ClusterInfo.Monitors)
 	return changed, nil
+}
+
+// restartMonIfStuckTerminating will check if a mon is on a node that is not ready.
+// If the pod is stuck in terminating state, go ahead and force delete the pod so K8s
+// will allow the mon to be restarted on another node.
+func (c *Cluster) restartMonIfStuckTerminating(monName string) error {
+	logger.Debugf("Checking for a stuck mon %q pod", monName)
+	labels := fmt.Sprintf("app=%s,mon=%s", AppName, monName)
+	pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(metav1.ListOptions{LabelSelector: labels})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get pod for mon %q", monName)
+	}
+	for _, pod := range pods.Items {
+		if err := k8sutil.ForceDeletePodIfStuck(c.context, pod); err != nil {
+			logger.Warningf("skipping forced restart of mon %q. %v", monName, err)
+		}
+	}
+	return nil
 }

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -291,7 +291,7 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 }
 
 func TestForceDeleteFailedMon(t *testing.T) {
-	clientset := test.New(t, 1)
+	clientset := test.New(1)
 	context := &clusterd.Context{
 		Clientset: clientset,
 	}

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	healthCheckInterval = 300 * time.Second
+	healthCheckInterval = 60 * time.Second
 )
 
 // OSDHealthMonitor defines OSD process monitoring

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -125,7 +125,7 @@ func TestOSDRestartIfStuck(t *testing.T) {
 		Clientset: clientset,
 	}
 
-	pod := &v1.Pod{
+	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "osd0",
 			Namespace: namespace,
@@ -136,13 +136,12 @@ func TestOSDRestartIfStuck(t *testing.T) {
 		},
 	}
 	pod.Spec.NodeName = "node0"
-	_, err := context.Clientset.CoreV1().Pods(namespace).Create(pod)
+	_, err := context.Clientset.CoreV1().Pods(namespace).Create(&pod)
 	assert.NoError(t, err)
 
 	m := NewOSDHealthMonitor(context, namespace, false, cephver.CephVersion{})
 
-	podList := &v1.PodList{Items: []v1.Pod{*pod}}
-	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+	assert.NoError(t, k8sutil.ForceDeletePodIfStuck(m.context, pod))
 
 	// The pod should still exist since it wasn't in a deleted state
 	p, err := context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
@@ -151,11 +150,10 @@ func TestOSDRestartIfStuck(t *testing.T) {
 
 	// Add a deletion timestamp to the pod
 	pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-	_, err = context.Clientset.CoreV1().Pods(namespace).Update(pod)
+	_, err = context.Clientset.CoreV1().Pods(namespace).Update(&pod)
 	assert.NoError(t, err)
 
-	podList = &v1.PodList{Items: []v1.Pod{*pod}}
-	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+	assert.NoError(t, k8sutil.ForceDeletePodIfStuck(m.context, pod))
 
 	// The pod should still exist since the node is ready
 	p, err = context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
@@ -171,7 +169,7 @@ func TestOSDRestartIfStuck(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+	assert.NoError(t, k8sutil.ForceDeletePodIfStuck(m.context, pod))
 
 	// The pod should be deleted since the pod is marked as deleted and the node is not ready
 	_, err = context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -31,9 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport changes to release-4.4 (backport of https://github.com/rook/rook/pull/5569) to improve the node failure handling.
- The monitoring goroutines that check for mon and osd health, the ceph cluster status, and the bucket provisioner should be started immediately with the first reconcile after an operator restart instead of waiting until the first reconcile is completed. This way the cluster health will be monitored even during the first reconcile.
- During the mon health check, if the mon is stuck terminating on a bad node, force delete the mon pod to allow it to start on another node if possible
- Reduce the OSD health check interval from 300s to 60s for faster response time in the event of node failure

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1835908

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
