### PR TITLE
Bug 1851311: Set the minimum rgw PGs for the metadata pools to the smaller default

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -42,6 +42,8 @@ const (
 	CrushTool             = "crushtool"
 	CmdExecuteTimeout     = 1 * time.Minute
 	cephConnectionTimeout = "15" // in seconds
+	// When PG count is 0, Ceph will use the internal default
+	DefaultPGCount = "0"
 )
 
 // CephConfFilePath returns the location to the cluster's config file in the operator container.

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -57,7 +57,7 @@ func TestCreateECPoolWithOverwrites(t *testing.T) {
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := CreateECPoolForApp(context, "myns", p, "myapp", true, model.ErasureCodedPoolConfig{DataChunkCount: 1})
+	err := CreateECPoolForApp(context, "myns", p, DefaultPGCount, "myapp", true, model.ErasureCodedPoolConfig{DataChunkCount: 1})
 	assert.Nil(t, err)
 }
 
@@ -89,7 +89,7 @@ func TestCreateECPoolWithoutOverwrites(t *testing.T) {
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := CreateECPoolForApp(context, "myns", p, "myapp", false, model.ErasureCodedPoolConfig{DataChunkCount: 1})
+	err := CreateECPoolForApp(context, "myns", p, DefaultPGCount, "myapp", false, model.ErasureCodedPoolConfig{DataChunkCount: 1})
 	assert.Nil(t, err)
 }
 
@@ -155,7 +155,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass s
 	}
 
 	p := CephStoragePoolDetails{Name: "mypool", Size: 12345, FailureDomain: failureDomain, CrushRoot: crushRoot, DeviceClass: deviceClass}
-	err := CreateReplicatedPoolForApp(context, "myns", p, "myapp")
+	err := CreateReplicatedPoolForApp(context, "myns", p, DefaultPGCount, "myapp")
 	assert.Nil(t, err)
 	assert.True(t, crushRuleCreated)
 }

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"strings"
 )
 
 // MonStore provides methods for setting Ceph configurations in the centralized mon
@@ -71,7 +72,7 @@ func (m *MonStore) Get(who, option string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get config setting %q for user %q", option, who)
 	}
-	return string(out), nil
+	return strings.TrimSpace(string(out)), nil
 }
 
 // SetAll sets all configs from the overrides in the centralized mon configuration database.

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -62,6 +62,18 @@ func (m *MonStore) Set(who, option, value string) error {
 	return nil
 }
 
+// Set sets a config in the centralized mon configuration database.
+// https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
+func (m *MonStore) Get(who, option string) (string, error) {
+	args := []string{"config", "get", who, normalizeKey(option)}
+	cephCmd := client.NewCephCommand(m.context, m.namespace, args)
+	out, err := cephCmd.Run()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get config setting %q for user %q", option, who)
+	}
+	return string(out), nil
+}
+
 // SetAll sets all configs from the overrides in the centralized mon configuration database.
 // See MonStore.Set for more.
 func (m *MonStore) SetAll(options ...Option) error {

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -297,6 +297,12 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool, p
 			if err != nil {
 				return errors.Errorf("failed to create pool %s for object store %s", name, context.Name)
 			}
+			if pgCount != ceph.DefaultPGCount {
+				err = ceph.SetPoolProperty(context.Context, context.ClusterName, name, "pg_num_min", pgCount)
+				if err != nil {
+					return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
+				}
+			}
 		}
 	}
 	return nil

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -297,11 +297,11 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool, p
 			if err != nil {
 				return errors.Errorf("failed to create pool %s for object store %s", name, context.Name)
 			}
-			if pgCount != ceph.DefaultPGCount {
-				err = ceph.SetPoolProperty(context.Context, context.ClusterName, name, "pg_num_min", pgCount)
-				if err != nil {
-					return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
-				}
+		}
+		// Set the pg_num_min if not the default so the autoscaler won't immediately increase the pg count
+		if pgCount != ceph.DefaultPGCount {
+			if err := ceph.SetPoolProperty(context.Context, context.ClusterName, name, "pg_num_min", pgCount); err != nil {
+				return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The object store was not getting created because of the PG limit. The rook operator log shows:

2020-06-26 10:30:39.906986 I | exec: Running command: ceph osd pool create ocs-storagecluster-cephobjectstore.rgw.buckets.index 0 replicated ocs-storagecluster-cephobjectstore.rgw.buckets.index --connect-timeout=15 --cluster=openshift-storage --conf=/var/lib/rook/openshift-storage/openshift-storage.config --keyring=/var/lib/rook/openshift-storage/client.admin.keyring --format json --out-file /tmp/875991478
2020-06-26 10:30:40.952434 I | exec: Error ERANGE:  pg_num 32 size 3 would mean 768 total pgs, which exceeds max 750 (mon_max_pg_per_osd 250 * num_in_osds 3)
2020-06-26 10:30:40.952568 E | op-object: failed to create or update object store ocs-storagecluster-cephobjectstore. failed to create pools: failed to create object pools: failed to create metadata pools: failed to create pool ocs-storagecluster-cephobjectstore.rgw.buckets.index for object store ocs-storagecluster-cephobjectstore

This is due to a change in Ceph 14.2.8 when the default PG count was set for all pools to 32. The expectation is that the rgw metadata pools should only set 8 PGs by default, which will keep us well below the max PG count. However, these changes had not been backported to 4.4. We are just now hitting it since the base image is 14.2.8 or newer.

This backport includes three PRs:
https://github.com/rook/rook/pull/5096
https://github.com/rook/rook/pull/5177
https://github.com/rook/rook/pull/5489
**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1851311

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
