### PR TITLE
Bug 1848184: Force delete mons in every reconcile and delay watching CRDs for first reconcile

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -454,21 +454,6 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	if !monitoringActivated {
 		c.startClusterMonitoring(cluster)
 	}
-}
-
-func (c *ClusterController) startClusterMonitoring(cluster *cluster) {
-	if cluster.Info == nil {
-		clusterInfo, _, _, err := mon.CreateOrLoadClusterInfo(c.context, cluster.Namespace, nil)
-		if err != nil {
-			logger.Errorf("failed to start osd monitoring. %v", err)
-			return
-		}
-		cluster.Info = clusterInfo
-		logger.Infof("cluster info loaded for monitoring: %+v", clusterInfo)
-	}
-
-	// enable the cluster monitoring goroutines once
-	logger.Infof("enabling cluster monitoring goroutines")
 
 	// Start client CRD watcher
 	clientController := cephclient.NewClientController(c.context, cluster.Namespace)
@@ -506,6 +491,21 @@ func (c *ClusterController) startClusterMonitoring(cluster *cluster) {
 	cluster.childControllers = []childController{
 		poolController, objectStoreController, objectStoreUserController, fileController, ganeshaController,
 	}
+}
+
+func (c *ClusterController) startClusterMonitoring(cluster *cluster) {
+	if cluster.Info == nil {
+		clusterInfo, _, _, err := mon.CreateOrLoadClusterInfo(c.context, cluster.Namespace, nil)
+		if err != nil {
+			logger.Errorf("failed to start osd monitoring. %v", err)
+			return
+		}
+		cluster.Info = clusterInfo
+		logger.Infof("cluster info loaded for monitoring: %+v", clusterInfo)
+	}
+
+	// enable the cluster monitoring goroutines once
+	logger.Infof("enabling cluster monitoring goroutines")
 
 	// Populate ClusterInfo
 	cluster.mons.ClusterInfo = cluster.Info

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -811,6 +811,9 @@ func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
 		}
 	}
 
+	// Restart the mon if it is stuck on a failed node
+	c.restartMonIfStuckTerminating(m.DaemonName)
+
 	err := updateDeploymentAndWait(c.context, d, c.Namespace, daemonType, m.DaemonName, cephVersionToUse, c.isUpgrade, c.spec.SkipUpgradeChecks, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update mon deployment %s", m.ResourceName)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two changes related to improving 1848184:
1. Force delete stuck mons in every reconcile: The stuck mons were only being force deleted in the mon health checker. After an operator restart, the health check may not be executed for 20 minutes until after the timeout during the main reconcile which is holding onto a lock for mon reconcile. Now the stuck mon will be deleted during the reconcile as well.
1. Delay watching for CRDs until first reconcile completes: The CRs cannot be reconciled until the operator first generates the ceph config, which doesn't happen until after the ceph image version is detected. This was causing the CR watches to fail since they were starting too soon. Now the CR watches will not start until after the first reconcile completes.
 
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1848184

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
