### PR TITLE
Bug 1849723: Revert "ceph: added PVC utilization alerts"

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -184,34 +184,6 @@ spec:
       for: 1h
       labels:
         severity: warning
-  - name: persistent-volume-alert.rules
-    rules:
-    - alert: PersistentVolumeUsageNearFull
-      annotations:
-        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed
-          75%. Free up some space.
-        message: PVC {{ $labels.persistentvolumeclaim }} is nearing full. Data deletion
-          is required.
-        severity_level: warning
-        storage_type: ceph
-      expr: |
-        (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.75
-      for: 5s
-      labels:
-        severity: warning
-    - alert: PersistentVolumeUsageCritical
-      annotations:
-        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed
-          85%. Free up some space immediately.
-        message: PVC {{ $labels.persistentvolumeclaim }} is critically full. Data
-          deletion is required.
-        severity_level: error
-        storage_type: ceph
-      expr: |
-        (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.85
-      for: 5s
-      labels:
-        severity: critical
   - name: cluster-state-alert.rules
     rules:
     - alert: CephClusterErrorState


### PR DESCRIPTION
This reverts commit 019cb74d79a31bf786a63fcc5d8a8d765d4964c5.
Reverts PR #76. 

This patch was only approved for 4.4.2.
Have to revet for a 4.4.1 respin.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

