### PR TITLE
Bug 1852852: Capture logging from the osd daemon

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -233,8 +233,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		{Name: "ROOK_IS_DEVICE", Value: "true"},
 	}...)
 
-	var commonArgs []string
-
 	// If the OSD runs on PVC
 	if osdProps.onPVC() {
 		// add the PVC size to the pod spec so that if the size changes the OSD will be restarted and pick up the change
@@ -248,9 +246,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			}
 		}
 	}
-
-	commonArgs = append(commonArgs, "--default-log-to-file", "false")
-	commonArgs = append(commonArgs, osdOnSDNFlag(c.Network)...)
 
 	var command []string
 	var args []string
@@ -319,7 +314,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		volumeMounts = append(volumeMounts, activateOSDContainer.VolumeMounts[0])
 	}
 
-	args = append(args, commonArgs...)
+	args = append(args, opconfig.LoggingFlags()...)
+	args = append(args, osdOnSDNFlag(c.Network)...)
 
 	osdDataDirPath := activateOSDMountPath + osdID
 	if osdProps.onPVC() && osd.CVMode == "lvm" {

--- a/pkg/operator/ceph/config/defaults.go
+++ b/pkg/operator/ceph/config/defaults.go
@@ -24,11 +24,26 @@ import (
 // DefaultFlags returns the default configuration flags Rook will set on the command line for all
 // calls to Ceph daemons and tools. Values specified here will not be able to be overridden using
 // the mon's central KV store, and that is (and should be) by intent.
-func DefaultFlags(fsid, mountedKeyringPath string, cephVersion version.CephVersion) []string {
+func DefaultFlags(fsid, mountedKeyringPath string) []string {
 	flags := []string{
 		// fsid unnecessary but is a safety to make sure daemons can only connect to their cluster
 		NewFlag("fsid", fsid),
 		NewFlag("keyring", mountedKeyringPath),
+	}
+
+	flags = append(flags, LoggingFlags()...)
+	flags = append(flags, StoredMonHostEnvVarFlags()...)
+
+	return flags
+}
+
+// makes it possible to be slightly less verbose to create a ConfigOverride here
+func configOverride(who, option, value string) Option {
+	return Option{Who: who, Option: option, Value: value}
+}
+
+func LoggingFlags() []string {
+	return []string{
 		// For containers, we're expected to log everything to stderr
 		NewFlag("log-to-stderr", "true"),
 		NewFlag("err-to-stderr", "true"),
@@ -38,15 +53,6 @@ func DefaultFlags(fsid, mountedKeyringPath string, cephVersion version.CephVersi
 		NewFlag("default-log-to-file", "false"),
 		NewFlag("default-mon-cluster-log-to-file", "false"),
 	}
-
-	flags = append(flags, StoredMonHostEnvVarFlags()...)
-
-	return flags
-}
-
-// makes it possible to be slightly less verbose to create a ConfigOverride here
-func configOverride(who, option, value string) Option {
-	return Option{Who: who, Option: option, Value: value}
 }
 
 // DefaultCentralizedConfigs returns the default configuration options Rook will set in Ceph's

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -263,7 +263,7 @@ func AddVolumeMountSubPath(podSpec *v1.PodSpec, volumeMountName string) {
 // DaemonFlags returns the command line flags used by all Ceph daemons.
 func DaemonFlags(cluster *cephconfig.ClusterInfo, daemonID string) []string {
 	return append(
-		config.DefaultFlags(cluster.FSID, keyring.VolumeMount().KeyringFilePath(), cluster.CephVersion),
+		config.DefaultFlags(cluster.FSID, keyring.VolumeMount().KeyringFilePath()),
 		config.NewFlag("id", daemonID),
 		// Ceph daemons in Rook will run as 'ceph' instead of 'root'
 		// If we run on a version of Ceph does not these flags it will simply ignore them
@@ -272,13 +272,12 @@ func DaemonFlags(cluster *cephconfig.ClusterInfo, daemonID string) []string {
 		// run ceph daemon process under the 'ceph' group
 		config.NewFlag("setgroup", "ceph"),
 	)
-
 }
 
 // AdminFlags returns the command line flags used for Ceph commands requiring admin authentication.
 func AdminFlags(cluster *cephconfig.ClusterInfo) []string {
 	return append(
-		config.DefaultFlags(cluster.FSID, keyring.VolumeMount().AdminKeyringFilePath(), cluster.CephVersion),
+		config.DefaultFlags(cluster.FSID, keyring.VolumeMount().AdminKeyringFilePath()),
 		config.NewFlag("setuser", "ceph"),
 		config.NewFlag("setgroup", "ceph"),
 	)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD daemon has been missing critical flags for logging to stderr where k8s can capture the logs. Without the --log-to-stderr=true, all the OSD logging was essentially lost until now.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1852852

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
