### PR TITLE
Bug 1840729: Reduce osd upgrade timeout from 10 minutes to one minute

### DIFF
--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -218,7 +218,7 @@ func okToStopDaemon(context *clusterd.Context, deployment, clusterName, daemonTy
 // This basically makes sure all the PGs have settled
 func okToContinueOSDDaemon(context *clusterd.Context, namespace string) error {
 	// Reconciliating PGs should not take too long so let's wait up to 10 minutes
-	err := util.Retry(10, 60*time.Second, func() error {
+	err := util.Retry(4, 15*time.Second, func() error {
 		return IsClusterCleanError(context, namespace)
 	})
 	if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The wait to continue after an OSD daemon upgrade is currently 10 minutes for the PGs to be healthy. This change reduced that retry timeout to one minute.

This is a minimal fix for OCS 4.5. A more completely configurable wait time will come in 4.6 with https://github.com/rook/rook/issues/5790.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1840729

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
