### PR TITLE
Bug 1852983: Revert "ceph: require rgw pods to be running to create object users"

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -265,7 +265,7 @@ func objectStoreInitialized(context *object.Context) (bool, error) {
 		return false, err
 	}
 	// check if at least one pod is running
-	if len(pods.Items) > 0 {
+	if pods != nil {
 		logger.Infof("CephObjectStore %s is running", context.Name)
 		return true, nil
 	}


### PR DESCRIPTION
This reverts commit 6f257d8a8f367735d28e67ff08440b670e5ca686.

This was merged too early.
Branch is still locked down for 4.4.2
Will have to re-add after opening for 4.4.3.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Revert PR #81 

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
