### PR TITLE
Bug 1856414: ceph: report error on timeout

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -62,10 +62,12 @@ type HealthStatus struct {
 }
 
 type CheckMessage struct {
-	Severity string `json:"severity"`
-	Summary  struct {
-		Message string `json:"message"`
-	} `json:"summary"`
+	Severity string  `json:"severity"`
+	Summary  Summary `json:"summary"`
+}
+
+type Summary struct {
+	Message string `json:"message"`
 }
 
 type MonMap struct {

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -166,7 +166,10 @@ func StatusWithUser(context *clusterd.Context, clusterName, userName string) (Ce
 
 	buf, err := context.Executor.ExecuteCommandWithOutput(command, args...)
 	if err != nil {
-		return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
+		if buf != "" {
+			return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
+		}
+		return CephStatus{}, errors.Wrap(err, "failed to get ceph status")
 	}
 
 	var status CephStatus


### PR DESCRIPTION
**Description of your changes:**

If the healthcheck goroutine cannot check for the ceph status/times out
(if the mons are not in quorum) this should still be reflected in the
CRD status field.

Example:

```
status:
  ceph:
    details:
      error:
        message: 'failed to get status. . timed out: exit status 1'
        severity: Urgent
    health: HEALTH_ERR
    lastChanged: "2020-07-20T14:11:05Z"
    lastChecked: "2020-07-20T14:11:05Z"
    previousHealth: HEALTH_WARN
```

Signed-off-by: Sébastien Han <seb@redhat.com>
