### PR TITLE
Bug 1851009: ceph: let the healthcheck set the status phase

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -27,6 +27,8 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/daemon/ceph/config"
+	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,16 +44,18 @@ type cephStatusChecker struct {
 	resourceName string
 	interval     time.Duration
 	externalCred config.ExternalCred
+	isExternal   bool
 }
 
 // newCephStatusChecker creates a new HealthChecker object
-func newCephStatusChecker(context *clusterd.Context, namespace, resourceName string, externalCred config.ExternalCred) *cephStatusChecker {
+func newCephStatusChecker(context *clusterd.Context, namespace, resourceName string, externalCred config.ExternalCred, isExternal bool) *cephStatusChecker {
 	c := &cephStatusChecker{
 		context:      context,
 		namespace:    namespace,
 		resourceName: resourceName,
 		interval:     defaultStatusCheckInterval,
 		externalCred: externalCred,
+		isExternal:   isExternal,
 	}
 
 	// allow overriding the check interval with an env var on the operator
@@ -104,20 +108,22 @@ func (c *cephStatusChecker) checkStatus() {
 	status, err = client.StatusWithUser(c.context, c.namespace, healthCheckUser)
 	if err != nil {
 		logger.Errorf("failed to get ceph status. %v", err)
-		if err := c.updateCephStatus(cephStatusOnError(err.Error())); err != nil {
+		condition, reason, message := c.conditionMessageReason(cephv1.ConditionFailure)
+		if err := c.updateCephStatus(cephStatusOnError(err.Error()), condition, reason, message); err != nil {
 			logger.Errorf("failed to query cluster status in namespace %q. %v", c.namespace, err)
 		}
 		return
 	}
 
 	logger.Debugf("Cluster status: %+v", status)
-	if err := c.updateCephStatus(&status); err != nil {
+	condition, reason, message := c.conditionMessageReason(cephv1.ConditionReady)
+	if err := c.updateCephStatus(&status, condition, reason, message); err != nil {
 		logger.Errorf("failed to query cluster status in namespace %q. %v", c.namespace, err)
 	}
 }
 
 // updateCephStatus detects the latest health status from ceph and updates the CR status
-func (c *cephStatusChecker) updateCephStatus(status *client.CephStatus) error {
+func (c *cephStatusChecker) updateCephStatus(status *client.CephStatus, condition cephv1.ConditionType, reason, message string) error {
 
 	// get the most recent cluster CRD object
 	cluster, err := c.context.RookClientset.CephV1().CephClusters(c.namespace).Get(c.resourceName, metav1.GetOptions{})
@@ -127,9 +133,14 @@ func (c *cephStatusChecker) updateCephStatus(status *client.CephStatus) error {
 
 	// translate the ceph status struct to the crd status
 	cluster.Status.CephStatus = toCustomResourceStatus(cluster.Status, status)
+	cluster.Status.Phase = condition
 	if _, err := c.context.RookClientset.CephV1().CephClusters(c.namespace).Update(cluster); err != nil {
 		return errors.Wrapf(err, "failed to update cluster %s status", c.namespace)
 	}
+
+	// Update condition
+	opconfig.ConditionExport(c.context, c.namespace, c.resourceName, condition, v1.ConditionTrue, reason, message)
+	logger.Debugf("ceph cluster %q status and condition updated to %+v, %v, %s, %s", c.namespace, status, v1.ConditionTrue, reason, message)
 
 	return nil
 }
@@ -177,4 +188,27 @@ func cephStatusOnError(errorMessage string) *cephclient.CephStatus {
 			Checks: details,
 		},
 	}
+}
+
+func (c *cephStatusChecker) conditionMessageReason(condition cephv1.ConditionType) (cephv1.ConditionType, string, string) {
+	var reason, message string
+
+	switch condition {
+	case cephv1.ConditionFailure:
+		reason = "ClusterFailure"
+		message = "Failed to configure ceph cluster"
+		if c.isExternal {
+			message = "Failed to configure external ceph cluster"
+		}
+	case cephv1.ConditionReady:
+		reason = "ClusterCreated"
+		message = "Cluster created successfully"
+		if c.isExternal {
+			condition = cephv1.ConditionConnected
+			reason = "ClusterConnected"
+			message = "Cluster connected successfully"
+		}
+	}
+
+	return condition, reason, message
 }

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -390,10 +390,6 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 		}
 	}
 
-	// Everything went well so let's update the CR's status to "connected"
-	config.ConditionExport(c.context, namespace, name,
-		cephv1.ConditionConnected, v1.ConditionTrue, "ClusterConnected", "Cluster connected successfully")
-
 	// Mark initialization has done
 	cluster.initCompleted = true
 
@@ -588,7 +584,7 @@ func (c *ClusterController) startClusterMonitoring(cluster *cluster) {
 	}
 
 	// Start the ceph status checker
-	cephChecker := newCephStatusChecker(c.context, cluster.Namespace, cluster.crdName, cluster.Info.ExternalCred)
+	cephChecker := newCephStatusChecker(c.context, cluster.Namespace, cluster.crdName, cluster.Info.ExternalCred, cluster.Spec.External.Enable)
 	go cephChecker.checkCephStatus(cluster.stopCh)
 }
 


### PR DESCRIPTION
**Description of your changes:**

Instead of setting the Phase of the CR once the reconcile is done, let's
actually set in from the healthcheck so it is more accurate.

Closes: https://github.com/rook/rook/issues/5249
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 65ddb49898ca19a683af349b196813134f4e44c7)
