### PR TITLE
Bug 1857304: ceph: make rgw option on external script

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -76,7 +76,7 @@ class RadosJSON:
                           help="Namespace where CephCluster is running")
         argP.add_argument("--rgw-pool-prefix", default="default",
                           help="RGW Pool prefix")
-        argP.add_argument("--rgw-endpoint", default="", required=True,
+        argP.add_argument("--rgw-endpoint", default="", required=False,
                           help="Rados GateWay endpoint (in <IP>:<PORT> format)")
         if args_to_parse:
             assert type(args_to_parse) == list, \


### PR DESCRIPTION
Some clusters do not have rgws deployed so let's make it optional.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit faad0a45acaed4679d96fcd30e39de21a7624f27)
