### PR TITLE
Bug 1859730: ceph: skip csi version detect if allowunsupported is set

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -28,9 +28,13 @@ import (
 )
 
 func ValidateAndStartDrivers(clientset kubernetes.Interface, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerRef *metav1.OwnerReference) {
-	if err := validateCSIVersion(clientset, namespace, rookImage, securityAccount, ownerRef); err != nil {
-		logger.Errorf("invalid csi version. %+v", err)
-		return
+	if !AllowUnsupported {
+		if err := validateCSIVersion(clientset, namespace, rookImage, securityAccount, ownerRef); err != nil {
+			logger.Errorf("invalid csi version. %+v", err)
+			return
+		}
+	} else {
+		logger.Info("Skipping csi version check, since unsupported versions are allowed")
 	}
 
 	if err := startDrivers(namespace, clientset, serverVersion, ownerRef); err != nil {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -538,10 +538,6 @@ func validateCSIVersion(clientset kubernetes.Interface, namespace, rookImage, se
 
 	version, err := extractCephCSIVersion(stdout)
 	if err != nil {
-		if AllowUnsupported {
-			logger.Infof("failed to extract csi version, but continuing since unsupported versions are allowed. %v", err)
-			return nil
-		}
 		return errors.Wrap(err, "failed to extract ceph CSI version")
 	}
 	logger.Infof("Detected ceph CSI image version: %q", version)


### PR DESCRIPTION
If the AllowUnsupported flag is set to true we should
not check the csi version as it will be kind of no-op
as even incase of failure we continue. if we disable
the version check in this case,the deployment will
be little faster as we dont wait for version check
to complete to start CSI pods.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 51d3a52c8078f8c621edaf11e7d0558f0903f4f4)
