### PR TITLE
Bug 1857304: ceph: make 'rgw_endpoint' check/validation also optional

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -315,8 +315,10 @@ class RadosJSON:
     def _gen_output_map(self):
         if self.out_map:
             return
-        self._invalid_endpoint(self._arg_parser.rgw_endpoint)
-        self.endpoint_dial(self._arg_parser.rgw_endpoint)
+        # if rgw_endpoint is provided, validate it
+        if self._arg_parser.rgw_endpoint:
+            self._invalid_endpoint(self._arg_parser.rgw_endpoint)
+            self.endpoint_dial(self._arg_parser.rgw_endpoint)
         if not self.cluster.pool_exists(self._arg_parser.rbd_data_pool_name):
             raise ExecutionFailureException(
                 "The provided 'rbd-data-pool-name': {}, don't exists".format(


### PR DESCRIPTION
As 'rgw_endpoint' argument itself is optional, making it's check / validation also optional

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>
(cherry picked from commit 59a3be6d7543af926a85e2082c287096b702cd41)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->
