### PR TITLE
ceph: change min encryption version for ocs

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -51,7 +51,7 @@ import (
 var (
 	logger                                            = capnslog.NewPackageLogger("github.com/rook/rook", "op-osd")
 	updateDeploymentAndWait                           = mon.UpdateCephDeploymentAndWait
-	cephVolumeRawEncryptionModeMinNautilusCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}
+	cephVolumeRawEncryptionModeMinNautilusCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 8}
 	cephVolumeRawEncryptionModeMinOctopusCephVersion  = cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}
 )
 


### PR DESCRIPTION
OCS 4.6 will run on RHCS 4.1z2 which has the encryption code but will
print 14.2.8 so let's change the min version.

Signed-off-by: Sébastien Han <seb@redhat.com>
