### PR TITLE
Revert "Bug 1876852: ceph: fix to support TLS enabled rgw-endpoint"

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -111,18 +111,17 @@ class RadosJSON:
                 "Out of range port number: {}".format(port))
         return False
 
-    def endpoint_dial(self, endpoint_str, timeout=3):
-        protocols = ["http", "https"]
-        for prefix in protocols:
-            try:
-                ep = "{}://{}".format(prefix, endpoint_str)
-                r = requests.head(ep, timeout=timeout)
-                if r.status_code == 200:
-                    return
-            except:
-                continue
-        raise ExecutionFailureException(
-            "unable to connect to endpoint: {}".format(endpoint_str))
+    def endpoint_dial(self, endpoint_str):
+        try:
+            ep = "http://" + endpoint_str
+            r = requests.head(ep)
+            rc = r.status_code
+            if rc != 200:
+                raise ExecutionFailureException(
+                    "wrong return code {} on rgw endpoint http header request".format(rc))
+        except requests.ConnectionError:
+            raise ExecutionFailureException(
+                "failed to connect to rgw endpoint {}".format(ep))
 
     def __init__(self, arg_list=None):
         self.out_map = {}


### PR DESCRIPTION
Reverts openshift/rook#120
I thought the build was locked downstream, but it might not be the case, so reverting this.