### PR TITLE
Bug 1879919: ceph: only run version check for monitoring

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -120,20 +120,20 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		}
 	}
 
-	// Discover external Ceph version
-	externalVersion, err := client.GetCephMonVersion(c.context, cluster.ClusterInfo)
-	if err != nil {
-		return errors.Wrap(err, "failed to get external ceph mon version")
-	}
-	cluster.ClusterInfo.CephVersion = *externalVersion
-
-	// Populate ceph version
-	c.updateClusterCephVersion("", *externalVersion)
-
 	// enable monitoring if `monitoring: enabled: true`
 	// We need the Ceph version
 	if cluster.Spec.Monitoring.Enabled {
-		err := c.configureExternalClusterMonitoring(cluster)
+		// Discover external Ceph version to detect which service monitor to inject
+		externalVersion, err := client.GetCephMonVersion(c.context, cluster.ClusterInfo)
+		if err != nil {
+			return errors.Wrap(err, "failed to get external ceph mon version")
+		}
+		cluster.ClusterInfo.CephVersion = *externalVersion
+
+		// Populate ceph version
+		c.updateClusterCephVersion("", *externalVersion)
+
+		err = c.configureExternalClusterMonitoring(cluster)
 		if err != nil {
 			return errors.Wrap(err, "failed to configure external cluster monitoring")
 		}


### PR DESCRIPTION
We only need to read the ceph cluster version if the cluster external
has external monitoring enabled.
This avoids any issue during upgrades from 1.3 to 1.4 when monitoring is
enabled and ceph caps have not been updated.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 6f894a6de87c497fa5f1417439d23b8ce3d384ff)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
