### PR TITLE
Bug 1885428: ceph: prevent closing of channel more than once

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -378,13 +378,10 @@ func (c *ClusterController) requestClusterDelete(cluster *cephv1.CephCluster) (r
 		}
 
 		// close the goroutines watching the health of the cluster (mons, osds, ceph status)
-		var isDisabled bool
 		for _, daemon := range monitorDaemonList {
-			isDisabled = isMonitoringDisabled(daemon, cluster.Spec)
-			if _, ok := cluster.monitoringChannels[daemon]; ok {
-				if !isDisabled {
-					close(cluster.monitoringChannels[daemon].stopChan)
-				}
+			if monitoring, ok := cluster.monitoringChannels[daemon]; ok && monitoring.monitoringRunning {
+				close(cluster.monitoringChannels[daemon].stopChan)
+				cluster.monitoringChannels[daemon].monitoringRunning = false
 			}
 		}
 	}


### PR DESCRIPTION
Once we close the channel for the monitoring daemons, we update the
monitoring status so as to not call them again.

This is to prevent "close of closed channel" panic.

Co-authored-by: Travis Nielsen <tnielsen@redhat.com>
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>
(cherry picked from commit 0c21abd535319ce4849d24a8b3a08d4555c69863)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
