### PR TITLE
BUG 1888545: ceph: remove owner reference set by rook on csidriver

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -166,6 +166,9 @@ rules:
   - csidrivers
   verbs:
   - create
+  - delete
+  - get
+  - update
 ---
 # Aspects of ceph-mgr that require cluster-wide access
 kind: ClusterRole

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -838,6 +838,9 @@ rules:
   - csidrivers
   verbs:
   - create
+  - delete
+  - get
+  - update
 ---
 # Aspects of ceph-mgr that require cluster-wide access
 kind: ClusterRole

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -505,15 +505,24 @@ func createCSIDriverInfo(clientset kubernetes.Interface, name string, ownerRef *
 		},
 	}
 	csidrivers := clientset.StorageV1beta1().CSIDrivers()
-	k8sutil.SetOwnerRef(&csiDriver.ObjectMeta, ownerRef)
-	_, err := csidrivers.Create(csiDriver)
+	driver, err := csidrivers.Get(name, metav1.GetOptions{})
 	if err == nil {
-		logger.Infof("CSIDriver object created for driver %q", name)
-		return nil
+		// For csidriver we need to provide the resourceVersion when updating the object.
+		// From the docs (https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+		// > "This value MUST be treated as opaque by clients and passed unmodified back to the server"
+		csiDriver.ObjectMeta.ResourceVersion = driver.ObjectMeta.ResourceVersion
+		_, err = csidrivers.Update(csiDriver)
+		if err == nil {
+			logger.Infof("CSIDriver object updated for driver %q", name)
+		}
+		return err
 	}
-	if apierrors.IsAlreadyExists(err) {
-		logger.Infof("CSIDriver CRD already had been registered for %q", name)
-		return nil
+
+	if apierrors.IsNotFound(err) {
+		_, err = csidrivers.Create(csiDriver)
+		if err == nil {
+			logger.Infof("CSIDriver object created for driver %q", name)
+		}
 	}
 
 	return err

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -860,6 +860,9 @@ rules:
   - csidrivers
   verbs:
   - create
+  - delete
+  - get
+  - update
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
currently, we are setting the rook operator as owner
on the csidriver objects,  as csidriver is cluster
scoped object we should not set namespaced object as
owner on cluster scoped object

fixes #6162

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit a1024ebc75f9c82a6874d6353c344a48f10e460e)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
