### PR TITLE
Bug 1891874: ceph: fix mon pdb reconcile

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/mon.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/mon.go
@@ -63,9 +63,10 @@ func (r *ReconcileClusterDisruption) reconcileMonPDB(cephCluster *cephv1.CephClu
 			MinAvailable: &intstr.IntOrString{IntVal: minAvailable},
 		},
 	}
+
 	err := r.reconcileStaticPDB(pdbRequest, pdb)
 	if err != nil {
-		return errors.Wrapf(err, "could not reconcile mon pdb")
+		return errors.Wrap(err, "failed to reconcile mon pdb")
 	}
 	return nil
 }

--- a/pkg/operator/ceph/disruption/clusterdisruption/mon_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/mon_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdisruption
+
+import (
+	"context"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
+	"github.com/stretchr/testify/assert"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func createFakeReconcileClusterDisruptionr(t *testing.T, obj ...runtime.Object) *ReconcileClusterDisruption {
+	scheme := scheme.Scheme
+	err := policyv1beta1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to build scheme")
+	}
+	client := fake.NewFakeClientWithScheme(scheme, obj...)
+
+	return &ReconcileClusterDisruption{
+		client: client,
+		scheme: scheme,
+	}
+}
+
+func TestReconcileMonPDB(t *testing.T) {
+	r := createFakeReconcileClusterDisruptionr(t, &cephv1.CephCluster{})
+	testCases := []struct {
+		label                string
+		cephCluster          *cephv1.CephCluster
+		expectedMinAvailable int32
+		errorExpected        bool
+	}{
+		{
+			label: "case 1: 0 mons",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: "rook-ceph"},
+			},
+			expectedMinAvailable: 0,
+			errorExpected:        true,
+		},
+		{
+			label: "case 2: 3 mons",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: "rook-ceph"},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 3,
+					},
+				},
+			},
+			expectedMinAvailable: 2,
+			errorExpected:        false,
+		},
+		{
+			label: "case 3: 5 mons",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: "rook-ceph"},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 5,
+					},
+				},
+			},
+			expectedMinAvailable: 3,
+			errorExpected:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := r.reconcileMonPDB(tc.cephCluster)
+		assert.NoError(t, err)
+		existingPDB := &policyv1beta1.PodDisruptionBudget{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: pdbName, Namespace: tc.cephCluster.Namespace}, existingPDB)
+		if tc.errorExpected {
+			assert.Error(t, err)
+			continue
+		}
+		assert.NoError(t, err)
+		assert.Equalf(t, tc.expectedMinAvailable, int32(existingPDB.Spec.MinAvailable.IntValue()), "[%s]: incorrect minAvailable count in pdb", tc.label)
+	}
+}


### PR DESCRIPTION
updated mon pdb reconcile to delete mon pdb and create a new one when mon count changes in the cluster spec

(cherry picked from commit 28cd611eb4c417bb3e3e71b56190630d430dc588)
Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
