### PR TITLE
Bug 1886348: Remove the osd pvc when purging the osd

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -18,13 +18,15 @@ package osd
 
 import (
 	"fmt"
+	"strconv"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
@@ -92,11 +94,11 @@ func removeOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdID
 				logger.Errorf("failed to delete deployment for OSD %d. %v", osdID, err)
 			}
 		}
-		const pvcLabelName = "ceph.rook.io/pvc"
-		if pvcName, ok := deployment.GetLabels()[pvcLabelName]; ok {
-			prepareJobList, err := context.Clientset.BatchV1().Jobs(clusterInfo.Namespace).List(metav1.ListOptions{LabelSelector: pvcLabelName + pvcName})
+		if pvcName, ok := deployment.GetLabels()[osd.OSDOverPVCLabelKey]; ok {
+			labelSelector := fmt.Sprintf("%s=%s", osd.OSDOverPVCLabelKey, pvcName)
+			prepareJobList, err := context.Clientset.BatchV1().Jobs(clusterInfo.Namespace).List(metav1.ListOptions{LabelSelector: labelSelector})
 			if err != nil && !kerrors.IsNotFound(err) {
-				logger.Errorf("failed to list prepareJobs with labels %q. %v ", pvcLabelName+pvcName, err)
+				logger.Errorf("failed to list osd prepare jobs with pvc %q. %v ", pvcName, err)
 			}
 			// Remove osd prepare job
 			for _, prepareJob := range prepareJobList.Items {
@@ -107,15 +109,17 @@ func removeOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdID
 						logger.Errorf("failed to delete prepare job for osd %q. %v", prepareJob.GetName(), err)
 					}
 				}
-
-				logger.Infof("removing the OSD PVC %q", pvcName)
-				if err := context.Clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).Delete(pvcName, &metav1.DeleteOptions{}); err != nil {
-					if err != nil {
-						// Continue deleting the OSD PVC even if PVC deletion fails
-						logger.Errorf("failed to delete pvc for OSD %q. %v", pvcName, err)
-					}
+			}
+			// Remove the OSD PVC
+			logger.Infof("removing the OSD PVC %q", pvcName)
+			if err := context.Clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).Delete(pvcName, &metav1.DeleteOptions{}); err != nil {
+				if err != nil {
+					// Continue deleting the OSD PVC even if PVC deletion fails
+					logger.Errorf("failed to delete pvc for OSD %q. %v", pvcName, err)
 				}
 			}
+		} else {
+			logger.Infof("did not find a pvc name to remove for osd %q", deploymentName)
 		}
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The osd purge job was not removing the osd prepare job or the osd pvc due to an invalid label query for the pvc. Now the prepare job and pvc will be removed as expected from the job.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1886348

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
