### PR TITLE
Bug 1890971: ceph: fail if mgr prometheus is not default

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -362,7 +362,14 @@ class RadosJSON:
         monitoring_endpoint = self._join_host_port(monitoring_endpoint_ip, monitoring_endpoint_port)
         self._invalid_endpoint(monitoring_endpoint)
         self.endpoint_dial(monitoring_endpoint)
+
+        self.validate_monitoring_endpoint(monitoring_endpoint_port)
         return monitoring_endpoint_ip, monitoring_endpoint_port
+
+    def validate_monitoring_endpoint(self, port):
+        if port != self.DEFAULT_MONITORING_ENDPOINT_PORT:
+            raise ExecutionFailureException(
+                "'prometheus' service port must listen on {}. You can change it with 'ceph config set mgr mgr/prometheus/server_port {}'.\n".format(self.DEFAULT_MONITORING_ENDPOINT_PORT, self.DEFAULT_MONITORING_ENDPOINT_PORT))
 
     def create_cephCSIKeyring_cephFSProvisioner(self):
         '''
@@ -937,8 +944,8 @@ class TestRadosJSON(unittest.TestCase):
         self.rjObj = RadosJSON(['--rbd-data-pool-name=abc', '--format=json'])
         self.rjObj.cluster = DummyRados.Rados()
 
-        valid_ip_ports = [("10.22.31.131", "3534"),
-                ("10.177.3.81", ""), ("", ""), ("", "9092")]
+        valid_ip_ports = [("10.22.31.131", "9283"),
+                          ("10.177.3.81", ""), ("", ""), ("", "9283")]
         for each_ip_port_pair in valid_ip_ports:
             # reset monitoring ip and port
             self.rjObj._arg_parser.monitoring_endpoint = ''


### PR DESCRIPTION
Currently, Rook does not support a prometheus exporter port different
than 9283 so let's fail and force the user to set it to the default.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 1ed307cb0991dfd716bce471c8f88e6a11b7def0)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
