### PR TITLE
Bug 1886859: ceph: ignore unscheduled ceph daemons while cleaning up

### DIFF
--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -186,6 +186,7 @@ func (c *ClusterController) waitForCephDaemonCleanUp(stopCleanupCh chan struct{}
 	}
 }
 
+// getCephHosts returns a list of host names where ceph daemon pods are running
 func (c *ClusterController) getCephHosts(namespace string) ([]string, error) {
 	cephPodCount := map[string]int{}
 	cephAppNames := []string{mon.AppName, mgr.AppName, osd.AppName, object.AppName, mds.AppName, rbd.AppName}
@@ -201,7 +202,7 @@ func (c *ClusterController) getCephHosts(namespace string) ([]string, error) {
 		}
 		for _, cephPod := range podList.Items {
 			podNodeName := cephPod.Spec.NodeName
-			if !nodeNameList.Contains(podNodeName) {
+			if podNodeName != "" && !nodeNameList.Contains(podNodeName) {
 				nodeNameList.Add(podNodeName)
 			}
 		}


### PR DESCRIPTION
Before cleaning up the cluster, we wait for all the daemon pods to be cleaned up. This fails when
a daemon is in pending state and has no NodeName. This PR ignores daemon pods that are not scheduled on any node.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 753bdb3526ab56e6c6ce51215a6b97099bda7df9)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
