### PR TITLE
Bug 1904171: RGW service selector should not change during upgrade to OCS 4.6

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -241,12 +241,11 @@ func (c *clusterConfig) generateLiveProbePort() intstr.IntOrString {
 }
 
 func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore) *v1.Service {
-	labels := getLabels(cephObjectStore.Name, cephObjectStore.Namespace, true)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instanceName(cephObjectStore.Name),
 			Namespace: cephObjectStore.Namespace,
-			Labels:    labels,
+			Labels:    getLabels(cephObjectStore.Name, cephObjectStore.Namespace, true),
 		},
 	}
 
@@ -262,7 +261,7 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 	} else {
 		// If the cluster is not external we add the Selector
 		svc.Spec = v1.ServiceSpec{
-			Selector: labels,
+			Selector: getLabels(cephObjectStore.Name, cephObjectStore.Namespace, false),
 		}
 	}
 	addPort(svc, "http", cephObjectStore.Spec.Gateway.Port, destPort.IntVal)


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the selector changes on the rgw service, during upgrade the clients will briefly not be able to connect to the rgw pods. After all the pods are updated with any new labels, the connections would be restored, but we want to avoid that temporary outage.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1904171

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
