### PR TITLE
Bug 1910760: ceph: fix c-v encryption min version

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -53,7 +53,7 @@ import (
 var (
 	logger                                            = capnslog.NewPackageLogger("github.com/rook/rook", "op-osd")
 	updateDeploymentAndWait                           = mon.UpdateCephDeploymentAndWait
-	cephVolumeRawEncryptionModeMinNautilusCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}
+	cephVolumeRawEncryptionModeMinNautilusCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 8}
 	cephVolumeRawEncryptionModeMinOctopusCephVersion  = cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}
 )
 


### PR DESCRIPTION
Downstream Ceph version sticks with 14.2.8 and adds up on the build
revision so the 14.2.11 coming from upstream prevents downstream from
working.

Resolves: #bz-1910760
Signed-off-by: Sébastien Han <seb@redhat.com>