### PR TITLE
Bug 1922064: ceph: check for orchestration cancellation while OSDs are pending

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -191,14 +191,19 @@ func (c *Cluster) Start() error {
 	logger.Infof("wait timeout for healthy OSDs during upgrade or restart is %q", c.clusterInfo.OsdUpgradeTimeout)
 
 	// start the jobs to provision the OSD devices
-	logger.Infof("start provisioning the osds on pvcs, if needed")
+	logger.Info("start provisioning the osds on PVCs, if needed")
 	c.startProvisioningOverPVCs(config)
 
-	logger.Infof("start provisioning the osds on nodes, if needed")
+	if len(config.errorMessages) > 0 {
+		return errors.Errorf("%d failures encountered while running osds on PVCs in namespace %q. %v",
+			len(config.errorMessages), c.clusterInfo.Namespace, strings.Join(config.errorMessages, "\n"))
+	}
+
+	logger.Info("start provisioning the osds on nodes, if needed")
 	c.startProvisioningOverNodes(config)
 
 	if len(config.errorMessages) > 0 {
-		return errors.Errorf("%d failures encountered while running osds in namespace %s: %+v",
+		return errors.Errorf("%d failures encountered while running osds on nodes in namespace %q. %v",
 			len(config.errorMessages), c.clusterInfo.Namespace, strings.Join(config.errorMessages, "\n"))
 	}
 


### PR DESCRIPTION
completeOSDsForAllNodes() method waits for 20 minutes for all the OSDs to start on all the nodes. This PR checks if
cluster deletion request was sent while waiting for OSDs to start. If yes, then completeOSDsForAllNodes() method will returnwithout waiting for 20 minutes.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit f5808185e0b6f198ecffe89a39b871ea6234d46d)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
