### PR TITLE
Bug 1922954: ceph: return an error if PVC is not clean

### DIFF
--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -37,10 +37,11 @@ const (
 	PVCNameEnvVarName         = "ROOK_PVC_NAME"
 	// CephVolumeEncryptedKeyEnvVarName is the env variable used by ceph-volume to encrypt the OSD (raw mode)
 	// Hardcoded in ceph-volume do NOT touch
-	CephVolumeEncryptedKeyEnvVarName    = "CEPH_VOLUME_DMCRYPT_SECRET"
-	osdMetadataDeviceEnvVarName         = "ROOK_METADATA_DEVICE"
-	osdWalDeviceEnvVarName              = "ROOK_WAL_DEVICE"
-	pvcBackedOSDVarName                 = "ROOK_PVC_BACKED_OSD"
+	CephVolumeEncryptedKeyEnvVarName = "CEPH_VOLUME_DMCRYPT_SECRET"
+	osdMetadataDeviceEnvVarName      = "ROOK_METADATA_DEVICE"
+	osdWalDeviceEnvVarName           = "ROOK_WAL_DEVICE"
+	// PVCBackedOSDVarName indicates whether the OSD is on PVC ("true") or not ("false")
+	PVCBackedOSDVarName                 = "ROOK_PVC_BACKED_OSD"
 	blockPathVarName                    = "ROOK_BLOCK_PATH"
 	cvModeVarName                       = "ROOK_CV_MODE"
 	lvBackedPVVarName                   = "ROOK_LV_BACKED_PV"
@@ -143,7 +144,7 @@ func metadataDeviceEnvVar(metadataDevice string) v1.EnvVar {
 }
 
 func pvcBackedOSDEnvVar(pvcBacked string) v1.EnvVar {
-	return v1.EnvVar{Name: pvcBackedOSDVarName, Value: pvcBacked}
+	return v1.EnvVar{Name: PVCBackedOSDVarName, Value: pvcBacked}
 }
 
 func setDebugLogLevelEnvVar(debug bool) v1.EnvVar {


### PR DESCRIPTION
With 5f57b6fd3abbab60b2992171e042598b3fdbf333, we introduced a
regression in the validation code.
If the OSD PV comes from another cluster, GetCephVolumeRawOSDs must
return an error.
The prepare job will crash loop but at least with a useful and
comprehensive message.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 7c928f4196518399302b59cdba974dfd48d8f953)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
