### PR TITLE
Bug 1927023: Add tolerations for all daemons to the cleanup job

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/placement.go
+++ b/pkg/apis/ceph.rook.io/v1/placement.go
@@ -40,8 +40,3 @@ func GetArbiterPlacement(p rookv1.PlacementSpec) rookv1.Placement {
 func GetOSDPlacement(p rookv1.PlacementSpec) rookv1.Placement {
 	return p.All().Merge(p[KeyOSD])
 }
-
-// GetCleanupPlacement returns the placement the cleanup job
-func GetCleanupPlacement(p rookv1.PlacementSpec) rookv1.Placement {
-	return p.All().Merge(p[KeyCleanup])
-}

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
@@ -157,9 +158,28 @@ func (c *ClusterController) cleanUpJobTemplateSpec(cluster *cephv1.CephCluster, 
 	cephv1.GetCleanupLabels(cluster.Spec.Labels).ApplyToObjectMeta(&podSpec.ObjectMeta)
 
 	// Apply placement
-	cephv1.GetCleanupPlacement(cluster.Spec.Placement).ApplyToPodSpec(&podSpec.Spec)
+	getCleanupPlacement(cluster.Spec).ApplyToPodSpec(&podSpec.Spec)
 
 	return podSpec
+}
+
+// getCleanupPlacement returns the placement for the cleanup job
+func getCleanupPlacement(c cephv1.ClusterSpec) rookv1.Placement {
+	// The cleanup jobs are assigned by the operator to a specific node, so the
+	// node affinity and other affinity are not needed for scheduling.
+	// The only placement required for the cleanup daemons is the tolerations.
+	tolerations := c.Placement[rookv1.KeyAll].Tolerations
+	tolerations = append(tolerations, c.Placement[cephv1.KeyCleanup].Tolerations...)
+	tolerations = append(tolerations, c.Placement[cephv1.KeyMonArbiter].Tolerations...)
+	tolerations = append(tolerations, c.Placement[cephv1.KeyMon].Tolerations...)
+	tolerations = append(tolerations, c.Placement[cephv1.KeyMgr].Tolerations...)
+	tolerations = append(tolerations, c.Placement[cephv1.KeyOSD].Tolerations...)
+
+	// Add the tolerations for all the device sets
+	for _, deviceSet := range c.Storage.StorageClassDeviceSets {
+		tolerations = append(tolerations, deviceSet.Placement.Tolerations...)
+	}
+	return rookv1.Placement{Tolerations: tolerations}
 }
 
 func (c *ClusterController) waitForCephDaemonCleanUp(stopCleanupCh chan struct{}, cluster *cephv1.CephCluster, retryInterval time.Duration) error {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The cleanup job will need to run wherever the ceph daemons were running. The scheduling is done by rook on the specific nodes where the daemons were running, so there is no need for other placement such as node or pod affinity.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1927023

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
