### PR TITLE
Bug 1931601: Consistently order the osd args to avoid restarts

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -147,27 +147,27 @@ fi
 )
 
 // OSDs on PVC using a certain fast storage class need to do some tuning
-var defaultTuneFastSettings = map[string]string{
-	"osd_op_num_threads_per_shard":        "2",          // Default value of osd_op_num_threads_per_shard for SSDs
-	"osd_op_num_shards":                   "8",          // Default value of osd_op_num_shards for SSDs
-	"osd_recovery_sleep":                  "0",          // Time in seconds to sleep before next recovery or backfill op for SSDs
-	"osd_snap_trim_sleep":                 "0",          // Time in seconds to sleep before next snap trim for SSDs
-	"osd_delete_sleep":                    "0",          // Time in seconds to sleep before next removal transaction for SSDs
-	"bluestore_min_alloc_size":            "4096",       // Default min_alloc_size value for SSDs
-	"bluestore_prefer_deferred_size":      "0",          // Default value of bluestore_prefer_deferred_size for SSDs
-	"bluestore_compression_min_blob_size": "8912",       // Default value of bluestore_compression_min_blob_size for SSDs
-	"bluestore_compression_max_blob_size": "65536",      // Default value of bluestore_compression_max_blob_size for SSDs
-	"bluestore_max_blob_size":             "65536",      // Default value of bluestore_max_blob_size for SSDs
-	"bluestore_cache_size":                "3221225472", // Default value of bluestore_cache_size for SSDs
-	"bluestore_throttle_cost_per_io":      "4000",       // Default value of bluestore_throttle_cost_per_io for SSDs
-	"bluestore_deferred_batch_ops":        "16",         // Default value of bluestore_deferred_batch_ops for SSDs
+var defaultTuneFastSettings = []string{
+	"--osd-op-num-threads-per-shard=2",            // Default value of osd_op_num_threads_per_shard for SSDs
+	"--osd-op-num-shards=8",                       // Default value of osd_op_num_shards for SSDs
+	"--osd-recovery-sleep=0",                      // Time in seconds to sleep before next recovery or backfill op for SSDs
+	"--osd-snap-trim-sleep=0",                     // Time in seconds to sleep before next snap trim for SSDs
+	"--osd-delete-sleep=0",                        // Time in seconds to sleep before next removal transaction for SSDs
+	"--bluestore-min-alloc-size=4096",             // Default min_alloc_size value for SSDs
+	"--bluestore-prefer-deferred-size=0",          // Default value of bluestore_prefer_deferred_size for SSDs
+	"--bluestore-compression-min-blob-size=8912",  // Default value of bluestore_compression_min_blob_size for SSDs
+	"--bluestore-compression-max-blob-size=65536", // Default value of bluestore_compression_max_blob_size for SSDs
+	"--bluestore-max-blob-size=65536",             // Default value of bluestore_max_blob_size for SSDs
+	"--bluestore-cache-size=3221225472",           // Default value of bluestore_cache_size for SSDs
+	"--bluestore-throttle-cost-per-io=4000",       // Default value of bluestore_throttle_cost_per_io for SSDs
+	"--bluestore-deferred-batch-ops=16",           // Default value of bluestore_deferred_batch_ops for SSDs
 }
 
 // OSDs on PVC using a certain slow storage class need to do some tuning
-var defaultTuneSlowSettings = map[string]string{
-	"osd_recovery_sleep":  "0.1", // Time in seconds to sleep before next recovery or backfill op
-	"osd_snap_trim_sleep": "2",   // Time in seconds to sleep before next snap trim
-	"osd_delete_sleep":    "2",   // Time in seconds to sleep before next removal transaction
+var defaultTuneSlowSettings = []string{
+	"--osd-recovery-sleep=0.1", // Time in seconds to sleep before next recovery or backfill op
+	"--osd-snap-trim-sleep=2",  // Time in seconds to sleep before next snap trim
+	"--osd-delete-sleep=2",     // Time in seconds to sleep before next removal transaction
 }
 
 func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionConfig *provisionConfig) (*apps.Deployment, error) {
@@ -296,13 +296,9 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 
 		// Append slow tuning flag if necessary
 		if osdProps.tuneSlowDeviceClass {
-			for flag, val := range defaultTuneSlowSettings {
-				args = append(args, opconfig.NewFlag(flag, val))
-			}
+			args = append(args, defaultTuneSlowSettings...)
 		} else if osdProps.tuneFastDeviceClass { // Append fast tuning flag if necessary
-			for flag, val := range defaultTuneFastSettings {
-				args = append(args, opconfig.NewFlag(flag, val))
-			}
+			args = append(args, defaultTuneFastSettings...)
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -335,16 +335,16 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	osdProp.tuneFastDeviceClass = true
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.NoError(t, err)
-	for flag, val := range defaultTuneFastSettings {
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, opconfig.NewFlag(flag, val))
+	for _, flag := range defaultTuneFastSettings {
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, flag)
 	}
 
 	// Test tune Slow settings when OSD on PVC
 	osdProp.tuneSlowDeviceClass = true
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.NoError(t, err)
-	for flag, val := range defaultTuneSlowSettings {
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, opconfig.NewFlag(flag, val))
+	for _, flag := range defaultTuneSlowSettings {
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, flag)
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The settings for tuneDeviceClass and tuneFastDeviceClass were stored as a map[string]string. When iterating over the map to append the args, the args were being appended in an unpredictable order. The order could change every reconcile, resulting in an unnecessary OSD restart potentially every reconcile. Now we iterate over a slice that will be ordered predictably and ensure OSDs will not be restarted when not needed.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1931601

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
