### PR TITLE
Bug 1936406: ceph: unmanage labels of monitoring resources

### DIFF
--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -78,8 +78,8 @@ func CreateOrUpdateServiceMonitor(serviceMonitorDefinition *monitoringv1.Service
 		}
 		return nil, fmt.Errorf("failed to retrieve servicemonitor. %v", err)
 	}
-	serviceMonitorDefinition.ResourceVersion = oldSm.ResourceVersion
-	sm, err := client.MonitoringV1().ServiceMonitors(namespace).Update(serviceMonitorDefinition)
+	oldSm.Spec = serviceMonitorDefinition.Spec
+	sm, err := client.MonitoringV1().ServiceMonitors(namespace).Update(oldSm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update servicemonitor. %v", err)
 	}
@@ -120,9 +120,8 @@ func CreateOrUpdatePrometheusRule(prometheusRule *monitoringv1.PrometheusRule) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to get prometheusRule object. %v", err)
 		}
-		prometheusRule.ObjectMeta.ResourceVersion = promRule.ObjectMeta.ResourceVersion
-
-		promRule, err = client.MonitoringV1().PrometheusRules(namespace).Update(prometheusRule)
+		promRule.Spec = prometheusRule.Spec
+		_, err = client.MonitoringV1().PrometheusRules(namespace).Update(promRule)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update prometheusRule. %v", err)
 		}


### PR DESCRIPTION


Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Do not reconcile ServiceMonitor/PrometheusRule on label updates.
This allows users to add custom labels which can be used by
custom Prometheus instances for monitoring.

**Which issue is resolved by this Pull Request:**
Backport of #7323

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
