### PR TITLE
Bug 1927922: ceph: Allow removal of arbitrary osds on pvcs and simplify pvc names

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -18,12 +18,16 @@ package osd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,85 +35,127 @@ import (
 func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv1.VolumeSource {
 	volumeSources := []rookv1.VolumeSource{}
 
-	existingPVCs, err := c.getExistingOSDPVCs()
+	existingPVCs, uniqueOSDsPerDeviceSet, err := GetExistingPVCs(c.context, c.clusterInfo.Namespace)
 	if err != nil {
 		config.addError("failed to detect existing OSD PVCs. %v", err)
 		return volumeSources
 	}
 
-	// Iterate over storageClassDeviceSet
-	for _, storageClassDeviceSet := range c.spec.Storage.StorageClassDeviceSets {
-		if err := controller.CheckPodMemory(cephv1.ResourcesKeyPrepareOSD, storageClassDeviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
-			config.addError("cannot use storageClassDeviceSet %q for creating osds %v", storageClassDeviceSet.Name, err)
+	// Iterate over deviceSet
+	for _, deviceSet := range c.spec.Storage.StorageClassDeviceSets {
+		if err := controller.CheckPodMemory(cephv1.ResourcesKeyPrepareOSD, deviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
+			config.addError("cannot use device set %q for creating osds %v", deviceSet.Name, err)
 			continue
 		}
-		for i := 0; i < storageClassDeviceSet.Count; i++ {
-			// Check if the volume claim template has PVCs
-			if len(storageClassDeviceSet.VolumeClaimTemplates) == 0 {
-				logger.Warningf("no PVC available for storageClassDeviceSet %q", storageClassDeviceSet.Name)
-				continue
-			}
+		// Check if the volume claim template is specified
+		if len(deviceSet.VolumeClaimTemplates) == 0 {
+			logger.Warningf("no volumeClaimTemplate specified for device set %q", deviceSet.Name)
+			continue
+		}
 
-			// Create the PVC source for each of the data, metadata, and other types of templates if defined.
-			pvcSources := map[string]v1.PersistentVolumeClaimVolumeSource{}
-			var dataSize string
-			var crushDeviceClass string
-			for _, pvcTemplate := range storageClassDeviceSet.VolumeClaimTemplates {
-				if pvcTemplate.Name == "" {
-					// For backward compatibility a blank name must be treated as a data volume
-					pvcTemplate.Name = bluestorePVCData
-				}
-
-				pvc, err := c.createStorageClassDeviceSetPVC(existingPVCs, storageClassDeviceSet.Name, pvcTemplate, i)
+		// Iterate through existing PVCs to ensure they are up-to-date, no metadata pvcs are missing, etc
+		highestExistingID := -1
+		countInDeviceSet := 0
+		if existingIDs, ok := uniqueOSDsPerDeviceSet[deviceSet.Name]; ok {
+			logger.Infof("verifying pvcs exist for %d osds in device set %q", existingIDs.Count(), deviceSet.Name)
+			for existingID := range existingIDs.Iter() {
+				pvcID, err := strconv.Atoi(existingID)
 				if err != nil {
-					config.addError("failed to create osd for storageClassDeviceSet %q for count %d. %v", storageClassDeviceSet.Name, i, err)
+					config.addError("invalid PVC index %q found for device set %q", existingID, deviceSet.Name)
 					continue
 				}
-
-				if pvcTemplate.Name == bluestorePVCData {
-					pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
-					dataSize = pvcSize.String()
-					crushDeviceClass = pvcTemplate.Annotations["crushDeviceClass"]
+				// keep track of the max PVC index found so we know what index to start with for new OSDs
+				if pvcID > highestExistingID {
+					highestExistingID = pvcID
 				}
-				pvcSources[pvcTemplate.Name] = v1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvc.GetName(),
-					ReadOnly:  false,
-				}
+				volumeSource := c.createDeviceSetPVCsForIndex(config, deviceSet, existingPVCs, pvcID)
+				volumeSources = append(volumeSources, volumeSource)
 			}
-
-			volumeSources = append(volumeSources, rookv1.VolumeSource{
-				Name:                storageClassDeviceSet.Name,
-				Resources:           storageClassDeviceSet.Resources,
-				Placement:           storageClassDeviceSet.Placement,
-				PreparePlacement:    storageClassDeviceSet.PreparePlacement,
-				Config:              storageClassDeviceSet.Config,
-				Size:                dataSize,
-				PVCSources:          pvcSources,
-				Portable:            storageClassDeviceSet.Portable,
-				TuneSlowDeviceClass: storageClassDeviceSet.TuneSlowDeviceClass,
-				TuneFastDeviceClass: storageClassDeviceSet.TuneFastDeviceClass,
-				SchedulerName:       storageClassDeviceSet.SchedulerName,
-				CrushDeviceClass:    crushDeviceClass,
-				Encrypted:           storageClassDeviceSet.Encrypted,
-			})
+			countInDeviceSet = existingIDs.Count()
+		}
+		// Create new PVCs if we are not yet at the expected count
+		// No new PVCs will be created if we have too many
+		pvcsToCreate := deviceSet.Count - countInDeviceSet
+		if pvcsToCreate > 0 {
+			logger.Infof("creating %d new PVCs for device set %q", pvcsToCreate, deviceSet.Name)
+		}
+		for i := 0; i < pvcsToCreate; i++ {
+			pvcID := highestExistingID + i + 1
+			volumeSource := c.createDeviceSetPVCsForIndex(config, deviceSet, existingPVCs, pvcID)
+			volumeSources = append(volumeSources, volumeSource)
+			countInDeviceSet++
 		}
 	}
 
 	return volumeSources
 }
 
-func (c *Cluster) createStorageClassDeviceSetPVC(existingPVCs map[string]*v1.PersistentVolumeClaim, storageClassDeviceSetName string, pvcTemplate v1.PersistentVolumeClaim, setIndex int) (*v1.PersistentVolumeClaim, error) {
+func (c *Cluster) createDeviceSetPVCsForIndex(config *provisionConfig, deviceSet rookv1.StorageClassDeviceSet, existingPVCs map[string]*v1.PersistentVolumeClaim, setIndex int) rookv1.VolumeSource {
+	// Create the PVC source for each of the data, metadata, and other types of templates if defined.
+	pvcSources := map[string]v1.PersistentVolumeClaimVolumeSource{}
+
+	var dataSize string
+	var crushDeviceClass string
+	for _, pvcTemplate := range deviceSet.VolumeClaimTemplates {
+		if pvcTemplate.Name == "" {
+			// For backward compatibility a blank name must be treated as a data volume
+			pvcTemplate.Name = bluestorePVCData
+		}
+
+		pvc, err := c.createDeviceSetPVC(existingPVCs, deviceSet.Name, pvcTemplate, setIndex)
+		if err != nil {
+			config.addError("failed to create osd for device set %q for count %d. %v", deviceSet.Name, setIndex, err)
+			continue
+		}
+
+		// The PVC type must be from a predefined set such as "data", "metadata", and "wal". These names must be enforced if the wal/db are specified
+		// with a separate device, but if there is a single volume template we can assume it is always the data template.
+		pvcType := pvcTemplate.Name
+		if len(deviceSet.VolumeClaimTemplates) == 1 {
+			pvcType = bluestorePVCData
+		}
+
+		if pvcType == bluestorePVCData {
+			pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			dataSize = pvcSize.String()
+			crushDeviceClass = pvcTemplate.Annotations["crushDeviceClass"]
+		}
+		pvcSources[pvcType] = v1.PersistentVolumeClaimVolumeSource{
+			ClaimName: pvc.GetName(),
+			ReadOnly:  false,
+		}
+	}
+
+	return rookv1.VolumeSource{
+		Name:                deviceSet.Name,
+		Resources:           deviceSet.Resources,
+		Placement:           deviceSet.Placement,
+		PreparePlacement:    deviceSet.PreparePlacement,
+		Config:              deviceSet.Config,
+		Size:                dataSize,
+		PVCSources:          pvcSources,
+		Portable:            deviceSet.Portable,
+		TuneSlowDeviceClass: deviceSet.TuneSlowDeviceClass,
+		TuneFastDeviceClass: deviceSet.TuneFastDeviceClass,
+		SchedulerName:       deviceSet.SchedulerName,
+		CrushDeviceClass:    crushDeviceClass,
+		Encrypted:           deviceSet.Encrypted,
+	}
+}
+
+func (c *Cluster) createDeviceSetPVC(existingPVCs map[string]*v1.PersistentVolumeClaim, deviceSetName string, pvcTemplate v1.PersistentVolumeClaim, setIndex int) (*v1.PersistentVolumeClaim, error) {
 	// old labels and PVC ID for backward compatibility
-	pvcStorageClassDeviceSetPVCId := legacyDeviceSetPVCID(storageClassDeviceSetName, setIndex)
+	pvcID := legacyDeviceSetPVCID(deviceSetName, setIndex)
 
 	// check for the existence of the pvc
-	existingPVC, ok := existingPVCs[pvcStorageClassDeviceSetPVCId]
+	existingPVC, ok := existingPVCs[pvcID]
 	if !ok {
 		// The old name of the PVC didn't exist, now try the new PVC name and label
-		pvcStorageClassDeviceSetPVCId = deviceSetPVCID(storageClassDeviceSetName, pvcTemplate.GetName(), setIndex)
-		existingPVC = existingPVCs[pvcStorageClassDeviceSetPVCId]
+		pvcID = deviceSetPVCID(deviceSetName, pvcTemplate.GetName(), setIndex)
+		existingPVC = existingPVCs[pvcID]
 	}
-	pvc := makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId, setIndex, pvcTemplate)
+	pvc := makeDeviceSetPVC(deviceSetName, pvcID, setIndex, pvcTemplate)
+	k8sutil.SetOwnerRef(&pvc.ObjectMeta, &c.clusterInfo.OwnerRef)
 
 	if existingPVC != nil {
 		logger.Infof("OSD PVC %q already exists", existingPVC.Name)
@@ -122,9 +168,10 @@ func (c *Cluster) createStorageClassDeviceSetPVC(existingPVCs map[string]*v1.Per
 	// No PVC found, creating a new one
 	deployedPVC, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).Create(pvc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create pvc %q for storageClassDeviceSet %q", pvc.GetGenerateName(), storageClassDeviceSetName)
+		return nil, errors.Wrapf(err, "failed to create pvc %q for device set %q", pvc.Name, deviceSetName)
 	}
 	logger.Infof("successfully provisioned PVC %q", deployedPVC.Name)
+
 	return deployedPVC, nil
 }
 
@@ -149,20 +196,20 @@ func (c *Cluster) updatePVCIfChanged(desiredPVC *v1.PersistentVolumeClaim, curre
 	}
 }
 
-func makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId string, setIndex int, pvcTemplate v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
-	pvcLabels := makeStorageClassDeviceSetPVCLabel(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId, setIndex)
-
-	// pvc naming format <storageClassDeviceSetName>-<SetNumber>-<PVCIndex>
-	pvcGenerateName := pvcStorageClassDeviceSetPVCId + "-"
+func makeDeviceSetPVC(deviceSetName, pvcID string, setIndex int, pvcTemplate v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
+	pvcLabels := makeStorageClassDeviceSetPVCLabel(deviceSetName, pvcID, setIndex)
 
 	// Add user provided labels to pvcTemplates
 	for k, v := range pvcTemplate.GetLabels() {
 		pvcLabels[k] = v
 	}
 
+	// pvc naming format rook-ceph-osd-<deviceSetName>-<SetNumber>-<PVCIndex>-<generatedSuffix>
 	return &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: pvcGenerateName,
+			// Use a generated name to avoid the possibility of two OSDs being created with the same ID.
+			// If one is removed and a new one is created later with the same ID, the OSD would fail to start.
+			GenerateName: pvcID,
 			Labels:       pvcLabels,
 			Annotations:  pvcTemplate.Annotations,
 		},
@@ -170,27 +217,39 @@ func makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDevi
 	}
 }
 
-func (c *Cluster) getExistingOSDPVCs() (map[string]*v1.PersistentVolumeClaim, error) {
+// GetExistingPVCs fetches the list of OSD PVCs
+func GetExistingPVCs(clusterdContext *clusterd.Context, namespace string) (map[string]*v1.PersistentVolumeClaim, map[string]*util.Set, error) {
 	selector := metav1.ListOptions{LabelSelector: CephDeviceSetPVCIDLabelKey}
-	pvcs, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).List(selector)
+	pvcs, err := clusterdContext.Clientset.CoreV1().PersistentVolumeClaims(namespace).List(selector)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to detect pvcs")
+		return nil, nil, errors.Wrap(err, "failed to detect pvcs")
 	}
 	result := map[string]*v1.PersistentVolumeClaim{}
+	uniqueOSDsPerDeviceSet := map[string]*util.Set{}
 	for i, pvc := range pvcs.Items {
+		// Populate the PVCs based on their unique name across all the device sets
 		pvcID := pvc.Labels[CephDeviceSetPVCIDLabelKey]
 		result[pvcID] = &pvcs.Items[i]
+
+		// Create a map of the PVC IDs available in each device set based on PVC index
+		deviceSet := pvc.Labels[CephDeviceSetLabelKey]
+		pvcIndex := pvc.Labels[CephSetIndexLabelKey]
+		if _, ok := uniqueOSDsPerDeviceSet[deviceSet]; !ok {
+			uniqueOSDsPerDeviceSet[deviceSet] = util.NewSet()
+		}
+		uniqueOSDsPerDeviceSet[deviceSet].Add(pvcIndex)
 	}
 
-	return result, nil
+	return result, uniqueOSDsPerDeviceSet, nil
 }
 
-func legacyDeviceSetPVCID(storageClassDeviceSetName string, setIndex int) string {
-	return fmt.Sprintf("%s-%d", storageClassDeviceSetName, setIndex)
+func legacyDeviceSetPVCID(deviceSetName string, setIndex int) string {
+	return fmt.Sprintf("%s-%d", deviceSetName, setIndex)
 }
 
 // This is the new function that generates the labels
 // It includes the pvcTemplateName in it
-func deviceSetPVCID(storageClassDeviceSetName, pvcTemplateName string, setIndex int) string {
-	return fmt.Sprintf("%s-%s-%d", storageClassDeviceSetName, strings.Replace(pvcTemplateName, " ", "-", -1), setIndex)
+func deviceSetPVCID(deviceSetName, pvcTemplateName string, setIndex int) string {
+	cleanName := strings.Replace(pvcTemplateName, " ", "-", -1)
+	return fmt.Sprintf("%s-%s-%d", deviceSetName, cleanName, setIndex)
 }

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package osd
 
 import (
+	"fmt"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -24,9 +25,13 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	testexec "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestPrepareDeviceSets(t *testing.T) {
@@ -34,10 +39,7 @@ func TestPrepareDeviceSets(t *testing.T) {
 	context := &clusterd.Context{
 		Clientset: clientset,
 	}
-	storageClass := "mysource"
-	claim := v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
-		StorageClassName: &storageClass,
-	}}
+	claim := testVolumeClaim("")
 	deviceSet := rookv1.StorageClassDeviceSet{
 		Name:                 "mydata",
 		Count:                1,
@@ -68,8 +70,154 @@ func TestPrepareDeviceSets(t *testing.T) {
 	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(pvcs.Items))
-	assert.Equal(t, "mydata-data-0-", pvcs.Items[0].GenerateName)
+	assert.Equal(t, "mydata-data-0", pvcs.Items[0].GenerateName)
 	assert.Equal(t, cluster.clusterInfo.Namespace, pvcs.Items[0].Namespace)
+}
+
+func TestPrepareDeviceSetWithHolesInPVCs(t *testing.T) {
+	clientset := testexec.New(t, 1)
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	deviceSet := rookv1.StorageClassDeviceSet{
+		Name:                 "mydata",
+		Count:                1,
+		Portable:             true,
+		VolumeClaimTemplates: []v1.PersistentVolumeClaim{testVolumeClaim("data"), testVolumeClaim("metadata"), testVolumeClaim("wal")},
+		SchedulerName:        "custom-scheduler",
+	}
+	spec := cephv1.ClusterSpec{
+		Storage: rookv1.StorageScopeSpec{StorageClassDeviceSets: []rookv1.StorageClassDeviceSet{deviceSet}},
+	}
+	ns := "testns"
+	cluster := &Cluster{
+		context:     context,
+		clusterInfo: client.AdminClusterInfo(ns),
+		spec:        spec,
+	}
+
+	pvcSuffix := 0
+	var pvcReactor k8stesting.ReactionFunc = func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		// PVCs are created with generateName used, and we need to capture the create calls and
+		// generate a name for them in order for PVCs to all have unique names.
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			t.Fatal("err! action is not a create action")
+			return false, nil, nil
+		}
+		obj := createAction.GetObject()
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatal("err! action not a PVC")
+			return false, nil, nil
+		}
+		if pvc.Name == "" {
+			pvc.Name = fmt.Sprintf("%s-%d", pvc.GenerateName, pvcSuffix)
+			logger.Info("generated name for PVC:", pvc.Name)
+			pvcSuffix++
+		} else {
+			logger.Info("PVC already has a name:", pvc.Name)
+		}
+		// setting pvc.Name above modifies the action in-place before future reactors occur
+		// we want the default reactor to create the resource, so return false as if we did nothing
+		return false, nil, nil
+	}
+	clientset.PrependReactor("create", "persistentvolumeclaims", pvcReactor)
+
+	// Create 3 PVCs for two OSDs in the device set
+	config := &provisionConfig{}
+	volumeSources := cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 1, len(volumeSources))
+	assert.Equal(t, 0, len(config.errorMessages))
+	assert.Equal(t, "mydata", volumeSources[0].Name)
+	assert.True(t, volumeSources[0].Portable)
+	_, dataOK := volumeSources[0].PVCSources["data"]
+	assert.True(t, dataOK)
+
+	// Verify the PVCs all exist
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(pvcs.Items))
+	assertPVCExists(t, clientset, ns, "mydata-data-0-0")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-0-1")
+	assertPVCExists(t, clientset, ns, "mydata-wal-0-2")
+
+	// Create 3 more PVCs (6 total) for two OSDs in the device set
+	cluster.spec.Storage.StorageClassDeviceSets[0].Count = 2
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	assert.Equal(t, 0, len(config.errorMessages))
+
+	// Verify the PVCs all exist
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+	assertPVCExists(t, clientset, ns, "mydata-data-0-0")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-0-1")
+	assertPVCExists(t, clientset, ns, "mydata-wal-0-2")
+	assertPVCExists(t, clientset, ns, "mydata-data-1-3")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-1-4")
+	assertPVCExists(t, clientset, ns, "mydata-wal-1-5")
+
+	// Verify the same number of PVCs exist after calling the reconcile again on the PVCs
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+
+	// Delete a single PVC and verify it will be re-created
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete("mydata-wal-0-2", &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+
+	// Delete the PVCs for an OSD and verify it will not be re-created if the count is reduced
+	cluster.spec.Storage.StorageClassDeviceSets[0].Count = 1
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete("mydata-data-0-0", &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete("mydata-metadata-0-1", &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete("mydata-wal-0-6", &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 1, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(pvcs.Items))
+
+	// Scale back up to a count of two and confirm that a new index is used for the PVCs
+	cluster.spec.Storage.StorageClassDeviceSets[0].Count = 2
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+	assertPVCExists(t, clientset, ns, "mydata-data-1-3")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-1-4")
+	assertPVCExists(t, clientset, ns, "mydata-wal-1-5")
+	assertPVCExists(t, clientset, ns, "mydata-data-2-7")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-2-8")
+	assertPVCExists(t, clientset, ns, "mydata-wal-2-9")
+}
+
+func assertPVCExists(t *testing.T, clientset kubernetes.Interface, namespace, name string) {
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims(namespace).Get(name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, pvc)
+}
+
+func testVolumeClaim(name string) v1.PersistentVolumeClaim {
+	storageClass := "mysource"
+	claim := v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
+		StorageClassName: &storageClass,
+	}}
+	claim.Name = name
+	return claim
 }
 
 func TestUpdatePVCSize(t *testing.T) {


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
OSDs on PVCs previously were always replaced with PVCs of a given name. For on-prem scenarios where the OSDs might need to be removed instead of replaced, the operator now allows holes to exist in the PVC index names as long as there are a sufficient number of PVCs to meet the criteria for the deviceSet.count.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1927922

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
