### PR TITLE
Bug 1935342: ceph: add osd flapping alert

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -125,6 +125,19 @@ spec:
       for: 40s
       labels:
         severity: critical
+    - alert: CephOSDFlapping
+      annotations:
+        description: Storage daemon {{ $labels.ceph_daemon }} has restarted 5 times
+          in last 5 minutes. Please check the pod events or ceph status to find out
+          the cause.
+        message: Ceph storage osd flapping.
+        severity_level: error
+        storage_type: ceph
+      expr: |
+        changes(ceph_osd_up[5m]) >= 10
+      for: 0s
+      labels:
+        severity: critical
     - alert: CephOSDNearFull
       annotations:
         description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class


### PR DESCRIPTION
Signed-off-by: Anmol Sachan <anmol13694@gmail.com>
(cherry picked from commit 1532070a3e6167de2f7860203ae13a75134fceed)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This PR adds an alert that notifies the users if an OSD restarts
for 5 times under 5 minutes. Each restart corresponds to 2 changes
in the value of ceph_osd_up metric.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
