### PR TITLE
Bug 1938367: ceph: enable snap schedule for downstream nautilus

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -275,7 +275,7 @@ func setCommonPoolProperties(context *clusterd.Context, clusterInfo *ClusterInfo
 		}
 
 		// Schedule snapshots
-		if pool.Mirroring.SnapshotSchedulesEnabled() && clusterInfo.CephVersion.IsAtLeastOctopus() {
+		if pool.Mirroring.SnapshotSchedulesEnabled() && clusterInfo.CephVersion.IsAtLeastNautilus() {
 			err = enableSnapshotSchedules(context, clusterInfo, pool, poolName)
 			if err != nil {
 				return errors.Wrapf(err, "failed to enable snapshot scheduling for pool %q", poolName)


### PR DESCRIPTION
Downstream nautilus has the code for rbd mirroring snapshots schedule so
we need to enable it.

Signed-off-by: Sébastien Han <seb@redhat.com>
