### PR TITLE
Bug 1937070: ceph: skip cleanup if cluster is not configured correctly

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -256,6 +256,7 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 
 	// DELETE: the CR was deleted
 	if !cephCluster.GetDeletionTimestamp().IsZero() {
+		doCleanup := true
 		logger.Infof("deleting ceph cluster %q", cephCluster.Name)
 
 		// Start cluster clean up only if cleanupPolicy is applied to the ceph cluster
@@ -266,22 +267,28 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 
 			monSecret, clusterFSID, err := r.clusterController.getCleanUpDetails(cephCluster.Namespace)
 			if err != nil {
-				return reconcile.Result{}, errors.Wrap(err, "failed to get mon secret, no cleanup")
+				logger.Warningf("failed to get mon secret. Skip cluster cleanup and remove finalizer. %v", err)
+				doCleanup = false
 			}
-			cephHosts, err := r.clusterController.getCephHosts(cephCluster.Namespace)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to find valid ceph hosts in the cluster %q", cephCluster.Namespace)
+
+			if doCleanup {
+				cephHosts, err := r.clusterController.getCephHosts(cephCluster.Namespace)
+				if err != nil {
+					return reconcile.Result{}, errors.Wrapf(err, "failed to find valid ceph hosts in the cluster %q", cephCluster.Namespace)
+				}
+				go r.clusterController.startClusterCleanUp(stopCleanupCh, cephCluster, cephHosts, monSecret, clusterFSID)
 			}
-			go r.clusterController.startClusterCleanUp(stopCleanupCh, cephCluster, cephHosts, monSecret, clusterFSID)
 		}
 
-		// Run delete sequence
-		response, ok := r.clusterController.requestClusterDelete(cephCluster)
-		if !ok {
-			// If the cluster cannot be deleted, requeue the request for deletion to see if the conditions
-			// will eventually be satisfied such as the volumes being removed
-			close(stopCleanupCh)
-			return response, nil
+		if doCleanup {
+			// Run delete sequence
+			response, ok := r.clusterController.requestClusterDelete(cephCluster)
+			if !ok {
+				// If the cluster cannot be deleted, requeue the request for deletion to see if the conditions
+				// will eventually be satisfied such as the volumes being removed
+				close(stopCleanupCh)
+				return response, nil
+			}
 		}
 
 		// Remove finalizer


### PR DESCRIPTION
deletion of cluster is stuck when cluster is not configured. The PR skips the cleanup and removes the finalizers if the cluster was not configured, that is, if clusterInfo could not be loaded.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 7bd05d0d7ca26caf3fcfefd4b4a514664559db33)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
