### PR TITLE
Bug 1939617: ceph: disable mon failover on stretched cluster

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -237,9 +237,16 @@ func (c *Cluster) failMon(monCount, desiredMonCount int, name string) {
 			logger.Errorf("failed to remove mon %q. %v", name, err)
 		}
 	} else {
-		// bring up a new mon to replace the unhealthy mon
-		if err := c.failoverMon(name); err != nil {
-			logger.Errorf("failed to failover mon %q. %v", name, err)
+		// NOTE(leseb): monitors cannot be failed over in stretch mode
+		// This is a hot-fix intended for the 4.7 release **only**
+		// See https://bugzilla.redhat.com/show_bug.cgi?id=1939617 for more details
+		if !c.spec.IsStretchCluster() {
+			// bring up a new mon to replace the unhealthy mon
+			if err := c.failoverMon(name); err != nil {
+				logger.Errorf("failed to failover mon %q. %v", name, err)
+			}
+		} else {
+			logger.Warning("refusing to failover monitor on a stretched cluster")
 		}
 	}
 }


### PR DESCRIPTION
**Description of your changes:**

As per, https://bugzilla.redhat.com/show_bug.cgi?id=1939617 mons
failover is failing on stretched clusters. The upstream Ceph fix will
not make it into 4.2.z1 and thus will miss OCS 4.7. So we need to
disable the mon failover from the code directly.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
