### PR TITLE
Bug 1942515: ceph: fix init container "expand-encrypted-bluefs" multipath

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -874,6 +874,14 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 	   Command successful.
 	*/
 
+	// Add /dev/mapper in the volume mount list
+	// This will fix issues when running on multi-path, where cryptsetup complains that the underlying device does not exist
+	// Essentially, the device cannot be found because it was not mounted in the container
+	// Typically, the device is mapped to the OSD data dir so it is mounted
+	volMount := []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)}
+	_, volMountMapper := getDeviceMapperVolume()
+	volMount = append(volMount, volMountMapper)
+
 	return v1.Container{
 		Name:  expandEncryptedPVCOSDInitContainer,
 		Image: c.spec.CephVersion.Image,
@@ -881,7 +889,7 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 			"cryptsetup",
 		},
 		Args:            []string{"--verbose", "resize", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
-		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)},
+		VolumeMounts:    volMount,
 		SecurityContext: PrivilegedContext(),
 		Resources:       osdProps.resources,
 	}

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -215,6 +215,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, "blkdevmapper-encryption", deployment.Spec.Template.Spec.InitContainers[1].Name)
 	assert.Equal(t, "encrypted-block-status", deployment.Spec.Template.Spec.InitContainers[2].Name)
 	assert.Equal(t, "expand-encrypted-bluefs", deployment.Spec.Template.Spec.InitContainers[3].Name)
+	assert.Equal(t, 2, len(deployment.Spec.Template.Spec.InitContainers[3].VolumeMounts), deployment.Spec.Template.Spec.InitContainers[3].VolumeMounts)
+	assert.Equal(t, "dev-mapper", deployment.Spec.Template.Spec.InitContainers[3].VolumeMounts[1].Name, deployment.Spec.Template.Spec.InitContainers[3].VolumeMounts)
 	assert.Equal(t, "activate", deployment.Spec.Template.Spec.InitContainers[4].Name)
 	assert.Equal(t, "expand-bluefs", deployment.Spec.Template.Spec.InitContainers[5].Name)
 	assert.Equal(t, "chown-container-data-dir", deployment.Spec.Template.Spec.InitContainers[6].Name)


### PR DESCRIPTION
When running encrypted OSDs on multipath the expand container was
failing to find the underlying device of the encrypted block. This was
because the underlying block was located in /dev/mapper and this path
wasn't mounted in the init container "expand-encrypted-bluefs".

This will manifest like so:

```
Underlying device for crypt device ocs-deviceset-block-dev-from-san-1-data-0-5qkmm-block-dmcrypt disappeared.
```

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 5762ca43b28bc9ff6d693452907a6f8535891dfb)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
