### PR TITLE
Bug 1946592: ceph: added rgw app label to appLabels for deleting stuck rook pods

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -301,6 +301,7 @@ func (c *cephStatusChecker) getRookPodsOnNode(node string) ([]v1.Pod, error) {
 		"rook-ceph-crashcollector",
 		"rook-ceph-mgr",
 		"rook-ceph-mds",
+		"rook-ceph-rgw",
 	}
 	podsOnNode := []v1.Pod{}
 	listOpts := metav1.ListOptions{

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -296,6 +296,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 		{"app": "rook-ceph-crashcollector"},
 		{"app": "rook-ceph-mgr"},
 		{"app": "rook-ceph-mds"},
+		{"app": "rook-ceph-rgw"},
 		{"app": "user-app"},
 		{"app": "rook-ceph-mon"},
 	}
@@ -325,7 +326,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 	pods, err := c.getRookPodsOnNode("node0")
 	assert.NoError(t, err)
 	// A pod is having two matching labels and its returned only once
-	assert.Equal(t, 10, len(pods))
+	assert.Equal(t, 11, len(pods))
 
 	podNames := []string{}
 	for _, pod := range pods {


### PR DESCRIPTION
Added the missing rgw app label to appLabels for deleting stuck rook pods

Signed-off-by: rohan47 <rohgupta@redhat.com>
(cherry picked from commit 06aa82620bef6d3cdad575b78ffdc9bb739bd9f9)
(cherry picked from commit 53d8d5bf46873b2b31da29acbc66c3693fd298b2)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
