### PR TITLE
Bug 1949558: ceph: add --public-addr args to ceph mds command

### DIFF
--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
@@ -100,6 +101,10 @@ func TestPodSpecs(t *testing.T) {
 	podTemplate.RunFullSuite(config.MdsType, "myfs-a", "rook-ceph-mds", "ns", "ceph/ceph:testversion",
 		"500", "250", "4337", "2169", /* resources */
 		"my-priority-class")
+
+	// assert --public-addr is appended to args
+	assert.Contains(t, d.Spec.Template.Spec.Containers[0].Args,
+		config.NewFlag("public-addr", controller.ContainerEnvVarReference(podIPEnvVar)))
 }
 
 func TestHostNetwork(t *testing.T) {
@@ -108,4 +113,8 @@ func TestHostNetwork(t *testing.T) {
 
 	assert.Equal(t, true, d.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, d.Spec.Template.Spec.DNSPolicy)
+
+	// assert --public-addr is not appended to args
+	assert.NotContains(t, d.Spec.Template.Spec.Containers[0].Args,
+		config.NewFlag("public-addr", controller.ContainerEnvVarReference(podIPEnvVar)))
 }


### PR DESCRIPTION
add --public-addr=<podIP> args to ceph mds command when host network is not enabled.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 5831c0f0d050b63e4b491b9aff3ddde3beb7fd17)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
