### PR TITLE
ceph: do not force go path in unit tests

### DIFF
--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package k8sutil
 
 import (
-	"os"
 	"path"
 	"testing"
 
@@ -38,8 +37,8 @@ func TestGetServiceMonitor(t *testing.T) {
 }
 
 func TestGetPrometheusRule(t *testing.T) {
-	gopath := os.Getenv("GOPATH")
-	filePath := path.Join(gopath, "src/github.com/rook/rook/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml")
+	projectRoot := util.PathToProjectRoot()
+	filePath := path.Join(projectRoot, "/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml")
 	rules, err := GetPrometheusRule(filePath)
 	assert.Nil(t, err)
 	assert.Equal(t, "prometheus-ceph-rules", rules.GetName())

--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -22,12 +22,13 @@ import (
 	"path"
 	"testing"
 
+	"github.com/rook/rook/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetServiceMonitor(t *testing.T) {
-	gopath := os.Getenv("GOPATH")
-	filePath := path.Join(gopath, "src/github.com/rook/rook/cluster/examples/kubernetes/ceph/monitoring/service-monitor.yaml")
+	projectRoot := util.PathToProjectRoot()
+	filePath := path.Join(projectRoot, "/cluster/examples/kubernetes/ceph/monitoring/service-monitor.yaml")
 	servicemonitor, err := GetServiceMonitor(filePath)
 	assert.Nil(t, err)
 	assert.Equal(t, "rook-ceph-mgr", servicemonitor.GetName())

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (
@@ -21,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/coreos/pkg/capnslog"
 )
@@ -47,4 +49,14 @@ func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 	}
 
 	logger.Infof("Config file %s:\n%s", path, string(contents))
+}
+
+// PathToProjectRoot returns the path to the root of the rook repo on the current host.
+// This is primarily useful for tests.
+func PathToProjectRoot() string {
+	_, path, _, _ := runtime.Caller(0) // get path to current file (<root>/pkg/util/file.go)
+	util := filepath.Dir(path)         // <root>/pkg/util
+	pkg := filepath.Dir(util)          // <root>/pkg
+	root := filepath.Dir(pkg)          // <root>
+	return root
 }

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 type Set struct {

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (


### PR DESCRIPTION
Needed for https://github.com/openshift/release/pull/17923 since GOPATH is not set.