### PR TITLE
Bug 1953360: Detect the osd topology affinity during upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -823,9 +823,13 @@ func (c *Cluster) getOSDInfo(d *apps.Deployment) ([]OSDInfo, error) {
 	}
 	osd.ID = osdID
 
+	isPVC := false
 	for _, envVar := range d.Spec.Template.Spec.Containers[0].Env {
 		if envVar.Name == "ROOK_OSD_UUID" {
 			osd.UUID = envVar.Value
+		}
+		if envVar.Name == "ROOK_PVC_BACKED_OSD" {
+			isPVC = true
 		}
 		if envVar.Name == "ROOK_BLOCK_PATH" || envVar.Name == "ROOK_LV_PATH" {
 			osd.BlockPath = envVar.Value
@@ -855,6 +859,14 @@ func (c *Cluster) getOSDInfo(d *apps.Deployment) ([]OSDInfo, error) {
 	// This property did not exist before so we need to initialize it
 	if osd.CVMode == "" {
 		osd.CVMode = "lvm"
+	}
+
+	// if the ROOK_TOPOLOGY_AFFINITY env var was not found in the loop above, detect it from the node
+	if isPVC && osd.TopologyAffinity == "" {
+		osd.TopologyAffinity, err = getTopologyFromNode(c.context.Clientset, d, osd)
+		if err != nil {
+			logger.Errorf("failed to get topology affinity for osd %d. %v", osd.ID, err)
+		}
 	}
 
 	locationFound := false
@@ -905,6 +917,36 @@ func getLocationFromPod(clientset kubernetes.Interface, d *apps.Deployment, crus
 	return GetLocationWithNode(clientset, nodeName, crushRoot, hostName)
 }
 
+func getTopologyFromNode(clientset kubernetes.Interface, d *apps.Deployment, osd OSDInfo) (string, error) {
+	portable, ok := d.GetLabels()[portableKey]
+	if !ok || portable != "true" {
+		// osd is not portable, no need to load the topology affinity
+		return "", nil
+	}
+	logger.Infof("detecting topology affinity for osd %d after upgrade", osd.ID)
+
+	// Get the osd pod and its assigned node, then look up the node labels
+	ctx := context.TODO()
+	pods, err := clientset.CoreV1().Pods(d.Namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", OsdIdLabelKey, d.Labels[OsdIdLabelKey])})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get osd pod")
+	}
+	if len(pods.Items) == 0 {
+		return "", errors.New("an osd pod does not exist")
+	}
+	nodeName := pods.Items[0].Spec.NodeName
+	if nodeName == "" {
+		return "", errors.Errorf("osd %d is not assigned to a node, cannot detect topology affinity", osd.ID)
+	}
+	node, err := getNode(clientset, nodeName)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get the node for topology affinity")
+	}
+	_, topologyAffinity := ExtractOSDTopologyFromLabels(node.Labels)
+	logger.Infof("found osd %d topology affinity at %q", osd.ID, topologyAffinity)
+	return topologyAffinity, nil
+}
+
 // GetLocationWithNode gets the topology information about the node. The return values are:
 //  location: The CRUSH properties for the OSD to apply
 //  topologyAffinity: The label to be applied to the OSD daemon to guarantee it will start in the same
@@ -913,7 +955,7 @@ func GetLocationWithNode(clientset kubernetes.Interface, nodeName string, crushR
 
 	node, err := getNode(clientset, nodeName)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "could not get the node for topology labels")
+		return "", "", errors.Wrap(err, "could not get the node for topology labels")
 	}
 
 	// If the operator did not pass a host name, look up the hostname label.

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -387,7 +387,7 @@ func TestGetOSDInfo(t *testing.T) {
 
 	node := "n1"
 	location := "root=default host=myhost zone=myzone"
-	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location}
+	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location, TopologyAffinity: "topology.rook.io/rack=rack0"}
 	osd2 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true}
 	osd3 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: ""}
 	osdProp := osdProperties{
@@ -396,6 +396,7 @@ func TestGetOSDInfo(t *testing.T) {
 		selection:     rookv1.Selection{},
 		resources:     v1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
+		portable:      true,
 	}
 	dataPathMap := &provisionConfig{
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.clusterInfo.Namespace, c.spec.DataDirHostPath),
@@ -409,6 +410,7 @@ func TestGetOSDInfo(t *testing.T) {
 	assert.Equal(t, osd1.CVMode, osds1[0].CVMode)
 	assert.Equal(t, location, osds1[0].Location)
 
+	osdProp.portable = false
 	d2, _ := c.makeDeployment(osdProp, osd2, dataPathMap)
 	osds2, _ := c.getOSDInfo(d2)
 	assert.Equal(t, 1, len(osds2))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The nodeAffinity for portable OSDs is needed to ensure the OSDs are tied to the same zone or other failure domain where the OSD was prepared and where it is expected to run. During upgrade the topology affinity was not being detected since the osd prepare job is skipped in that case. Now the topology will be detected from the running OSD daemon pod's node.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1953360

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
