### PR TITLE
Bug 1950419: ceph: update podDisruptionBudget controller for OSD

### DIFF
--- a/design/ceph/ceph-managed-disruptionbudgets.md
+++ b/design/ceph/ceph-managed-disruptionbudgets.md
@@ -18,7 +18,7 @@ Even if an upgrade agent were only to drain one node at a time, Ceph would have 
 The failure domain will be determined by the smallest failure domain of all the Ceph Pools in that cluster.
 We begin with creating a single PodDisruptionBudget for all the OSD with maxUnavailable=1. This will allow one OSD to go down anytime. Once the user drains a node and an OSD goes down, we determine the failure domain for the draining OSD (using the OSD deployment labels). Then we create blocking PodDisruptionBudgets (maxUnavailable=0) for all other failure domains and delete the main PodDisruptionBudget. This blocks OSDs from going down in multiple failure domains simultaneously.
 
-Once the drained OSDs are back and all the pgs are active+clean, that is, the cluster is healed, the main PodDisruptionBudget is added back and the blocking ones are deleted. User can also add a timeout for the pgs to become healthy. If the timeout exceeds, the operator will ignore the pg health, add the main PodDisruptionBudget and delete the blocking ones.
+Once the drained OSDs are back and all the pgs are active+clean, that is, the cluster is healed, the default PodDisruptionBudget (with maxUnavailable=1) is added back and the blocking ones are deleted. User can also add a timeout for the pgs to become healthy. If the timeout exceeds, the operator will ignore the pg health, add the main PodDisruptionBudget and delete the blocking ones.
 
 Detecting drains is not easy as they are a client side operation. The client cordons the node and continuously attempts to evict all pods from the node until it succeeds. Whenever an OSD goes into pending state, that is, `ReadyReplicas` count is 0, we assume that some drain operation is happening.
 
@@ -51,6 +51,8 @@ An example of an operator that will attempt to do rolling upgrades of nodes is t
 a common way of deploying kubernetes. This will also work to mitigate manual drains from accidentally disrupting storage.
 
 When an node is drained, we will also delay it's DOWN/OUT process by placing a noout on that node. We will remove that noout after a timeout.
+
+An OSD can be down due to reasons other than node drain, say, disk failure. In such a situation, if the pgs are unhealthy then rook will create a blocking PodDisruptionBudget on other failure domains to prevent further node drains on them. `noout` flag won't be set on node this is case. If the OSD is down but all the pgs are `active+clean`, the cluster will be treated as fully healthy. The default PodDisruptionBudget (with maxUnavailable=1) will be added back and the blocking ones will be deleted.
 
 ### Mon, Mgr, MDS, RGW, RBDMirror
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -46,6 +46,7 @@ const (
 	osdPDBAppName                    = "rook-ceph-osd"
 	drainingFailureDomainKey         = "draining-failure-domain"
 	drainingFailureDomainDurationKey = "draining-failure-domain-duration"
+	setNoOut                         = "set-no-out"
 	pgHealthCheckDurationKey         = "pg-health-check-duration"
 	// DefaultMaintenanceTimeout is the period for which a drained failure domain will remain in noout
 	DefaultMaintenanceTimeout = 30 * time.Minute
@@ -68,9 +69,9 @@ func (r *ReconcileClusterDisruption) deletePDB(pdb *policyv1beta1.PodDisruptionB
 	return nil
 }
 
-// createOverallPDBforOSD creates a single PDB for all OSDs with maxUnavailable=1
+// createDefaultPDBforOSD creates a single PDB for all OSDs with maxUnavailable=1
 // This allows all OSDs in a single failure domain to go down.
-func (r *ReconcileClusterDisruption) createOverallPDBforOSD(namespace string) error {
+func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string) error {
 	cephCluster, ok := r.clusterMap.GetCluster(namespace)
 	if !ok {
 		return errors.Errorf("failed to find the namespace %q in the clustermap", namespace)
@@ -97,8 +98,8 @@ func (r *ReconcileClusterDisruption) createOverallPDBforOSD(namespace string) er
 	err = r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("all osds are up. pg health is active+clean")
-			logger.Infof("creating the main pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
+			logger.Info("all PGs are active+clean. Restoring default OSD pdb settings")
+			logger.Infof("creating the default pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
 			return r.createPDB(pdb)
 		}
 		return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
@@ -106,7 +107,7 @@ func (r *ReconcileClusterDisruption) createOverallPDBforOSD(namespace string) er
 	return nil
 }
 
-func (r *ReconcileClusterDisruption) deleteOverallPDBforOSD(namespace string) error {
+func (r *ReconcileClusterDisruption) deleteDefaultPDBforOSD(namespace string) error {
 	pdbRequest := types.NamespacedName{Name: osdPDBAppName, Namespace: namespace}
 	pdb := &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +122,7 @@ func (r *ReconcileClusterDisruption) deleteOverallPDBforOSD(namespace string) er
 		}
 		return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
 	}
-	logger.Infof("deleting the main pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
+	logger.Infof("deleting the default pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
 	return r.deletePDB(pdb)
 }
 
@@ -198,7 +199,7 @@ func (r *ReconcileClusterDisruption) initializePDBState(request reconcile.Reques
 
 	if apierrors.IsNotFound(err) {
 		// create configmap to track the draining failure domain
-		pdbStateMap.Data = map[string]string{drainingFailureDomainKey: ""}
+		pdbStateMap.Data = map[string]string{drainingFailureDomainKey: "", setNoOut: ""}
 		err := r.client.Create(context.TODO(), pdbStateMap)
 		if err != nil {
 			return pdbStateMap, errors.Wrapf(err, "failed to create the PDB state map %q", pdbStateMapRequest)
@@ -215,74 +216,100 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 	pdbStateMap *corev1.ConfigMap,
 	failureDomainType string,
 	allFailureDomains,
-	drainingFailureDomains []string,
-) error {
+	osdDownFailureDomains []string,
+	activeNodeDrains bool,
+) (reconcile.Result, error) {
+	var osdDown bool
+	var drainingFailureDomain string
+	if len(osdDownFailureDomains) > 0 {
+		osdDown = true
+		drainingFailureDomain = osdDownFailureDomains[0]
+	}
 
-	pgHealthMsg, clean, err := cephclient.IsClusterClean(r.context.ClusterdContext, clusterInfo)
+	pgHealthMsg, pgClean, err := cephclient.IsClusterClean(r.context.ClusterdContext, clusterInfo)
 	if err != nil {
 		// If the error contains that message, this means the cluster is not up and running
 		// No monitors are present and thus no ceph configuration has been created
 		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
-			logger.Debugf("Ceph %q cluster not ready, cannot check Ceph status yet.", request.Namespace)
-			return nil
+			logger.Infof("Ceph %q cluster not ready, cannot check Ceph status yet.", request.Namespace)
+			return opcontroller.WaitForRequeueIfOperatorNotInitialized, nil
 		}
-		return errors.Wrapf(err, "failed to check cluster health")
+		return reconcile.Result{}, errors.Wrapf(err, "failed to check cluster health")
 	}
 
-	if pdbStateMap.Data == nil {
-		pdbStateMap.Data = make(map[string]string)
-	}
-	_, ok := pdbStateMap.Data[drainingFailureDomainKey]
-	if !ok {
-		pdbStateMap.Data[drainingFailureDomainKey] = ""
-	}
-
-	var drainingFailureDomain string
-	activeDrains := len(drainingFailureDomains) > 0
-
-	// create blocking PDBs for all the OSDs that are not being drained right now
-	if activeDrains {
-		drainingFailureDomain = drainingFailureDomains[0]
-		logger.Infof("all %q failure domains: %v. currently draining: %q. pg health: %q", failureDomainType,
-			allFailureDomains, drainingFailureDomain, pgHealthMsg)
-		err := r.handleActiveDrains(allFailureDomains, drainingFailureDomain, failureDomainType, clusterInfo.Namespace, clean)
+	switch {
+	// osd is down but pgs are active+clean
+	case osdDown && pgClean:
+		lastDrainTimeStamp, err := getLastDrainTimeStamp(pdbStateMap, drainingFailureDomainDurationKey)
 		if err != nil {
-			return errors.Wrap(err, "failed to handle active drains")
+			return reconcile.Result{}, errors.Wrapf(err, "failed to get last drain timestamp from the configmap %q", pdbStateMap.Name)
 		}
+		timeSinceOSDDown := time.Since(lastDrainTimeStamp)
+		if timeSinceOSDDown > 30*time.Second {
+			logger.Infof("osd is down in failure domain %q is down for the last %.2f minutes, but pgs are active+clean", drainingFailureDomain, timeSinceOSDDown.Minutes())
+			resetPDBConfig(pdbStateMap)
+		} else {
+			logger.Infof("osd is down in the failure domain %q, but pgs are active+clean. Requeuing in case pg status is not updated yet...", drainingFailureDomain)
+			return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
+		}
+
+	// osd is down and pgs are not healthy
+	case osdDown && !pgClean:
+		logger.Infof("osd is down in failure domain %q and pgs are not active+clean. pg health: %q", drainingFailureDomain, pgHealthMsg)
 		currentlyDrainingFD, ok := pdbStateMap.Data[drainingFailureDomainKey]
 		if !ok || drainingFailureDomain != currentlyDrainingFD {
 			pdbStateMap.Data[drainingFailureDomainKey] = drainingFailureDomain
 			pdbStateMap.Data[drainingFailureDomainDurationKey] = time.Now().Format(time.RFC3339)
 		}
-	} else if clean || r.hasPGHealthCheckTimedout(pdbStateMap) {
+		if activeNodeDrains {
+			pdbStateMap.Data[setNoOut] = "true"
+		}
+
+	// osd is back up and either pgs have become healthy or pg healthy check timeout has elapsed
+	case !osdDown && (pgClean || r.hasPGHealthCheckTimedout(pdbStateMap)):
 		// reset the configMap if cluster is clean or if the timeout for PGs to become active+clean has exceeded
-		logger.Debugf("no drains detected in %q failure domains: %v. pg health: %q", failureDomainType, allFailureDomains, pgHealthMsg)
-		pdbStateMap.Data[drainingFailureDomainKey] = ""
-		delete(pdbStateMap.Data, drainingFailureDomainDurationKey)
-		delete(pdbStateMap.Data, pgHealthCheckDurationKey)
-	} else {
-		logger.Infof("all osds are up. last drained failure domain: %q.  pg health: %q. waiting for PGs to be active+clean or PG health check to timeout",
-			pdbStateMap.Data[drainingFailureDomainKey], pgHealthMsg)
+		logger.Debugf("no OSD is down in the %q failure domains: %v. pg health: %q", failureDomainType, allFailureDomains, pgHealthMsg)
+		resetPDBConfig(pdbStateMap)
+
+	default:
+		logger.Infof("all %q failure domains: %v. osd is down in failure domain: %q. active node drains: %t. pg health: %q", failureDomainType,
+			allFailureDomains, drainingFailureDomain, activeNodeDrains, pgHealthMsg)
 	}
 
-	err = r.updateNoout(clusterInfo, pdbStateMap, allFailureDomains)
-	if err != nil {
-		logger.Errorf("failed to update maintenance noout in cluster %q. %v", request, err)
+	if pdbStateMap.Data[setNoOut] == "true" {
+		err = r.updateNoout(clusterInfo, pdbStateMap, allFailureDomains)
+		if err != nil {
+			logger.Errorf("failed to update maintenance noout in cluster %q. %v", request, err)
+		}
+	}
+
+	if pdbStateMap.Data[drainingFailureDomainKey] != "" && !pgClean {
+		// delete default OSD pdb and create blocking OSD pdbs
+		err := r.handleActiveDrains(allFailureDomains, pdbStateMap.Data[drainingFailureDomainKey], failureDomainType, clusterInfo.Namespace, pgClean)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to handle active drains")
+		}
+	} else if pdbStateMap.Data[drainingFailureDomainKey] == "" {
+		// delete all blocking OSD pdb and restore the default OSD pdb
+		err := r.handleInactiveDrains(allFailureDomains, failureDomainType, clusterInfo.Namespace)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to handle inactive drains")
+		}
+		// reset `set-no-out` flag on the configMap
+		pdbStateMap.Data[setNoOut] = ""
 	}
 
 	err = r.client.Update(context.TODO(), pdbStateMap)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update configMap %q in cluster %q", pdbStateMapName, request)
+		return reconcile.Result{}, errors.Wrapf(err, "failed to update configMap %q in cluster %q", pdbStateMapName, request)
 	}
 
-	// handle inactive drains by deleting all blocking pdb and restoring the main pdb
-	if pdbStateMap.Data[drainingFailureDomainKey] == "" {
-		err := r.handleInactiveDrains(allFailureDomains, clusterInfo.Namespace, failureDomainType)
-		if err != nil {
-			return errors.Wrap(err, "failed to handle inactive drains")
-		}
+	// requeue if drain is still in progress
+	if len(pdbStateMap.Data[drainingFailureDomainKey]) > 0 {
+		return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 	}
-	return nil
+
+	return reconcile.Result{}, nil
 }
 
 func (r *ReconcileClusterDisruption) handleActiveDrains(allFailureDomains []string, drainingFailureDomain,
@@ -305,20 +332,20 @@ func (r *ReconcileClusterDisruption) handleActiveDrains(allFailureDomains []stri
 		}
 	}
 
-	// delete the main PDB for OSD
+	// delete the default PDB for OSD
 	// This will allow all OSDs in the currently drained failure domain to be removed.
-	logger.Debug("deleting main pdb with maxUnavailable=1 for all osd")
-	err := r.deleteOverallPDBforOSD(namespace)
+	logger.Debug("deleting default pdb with maxUnavailable=1 for all osd")
+	err := r.deleteDefaultPDBforOSD(namespace)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete the main osd pdb")
+		return errors.Wrap(err, "failed to delete the default osd pdb")
 	}
 	return nil
 }
 
-func (r *ReconcileClusterDisruption) handleInactiveDrains(allFailureDomains []string, namespace, failureDomainType string) error {
-	err := r.createOverallPDBforOSD(namespace)
+func (r *ReconcileClusterDisruption) handleInactiveDrains(allFailureDomains []string, failureDomainType, namespace string) error {
+	err := r.createDefaultPDBforOSD(namespace)
 	if err != nil {
-		return errors.Wrap(err, "failed to create main pdb")
+		return errors.Wrap(err, "failed to create default pdb")
 	}
 	for _, failureDomainName := range allFailureDomains {
 		err := r.deleteBlockingPDBForOSD(namespace, failureDomainType, failureDomainName)
@@ -375,37 +402,51 @@ func (r *ReconcileClusterDisruption) updateNoout(clusterInfo *cephclient.Cluster
 	return nil
 }
 
-func (r *ReconcileClusterDisruption) getOSDFailureDomains(clusterInfo *cephclient.ClusterInfo, request reconcile.Request, poolFailureDomain string) ([]string, []string, error) {
+func (r *ReconcileClusterDisruption) getOSDFailureDomains(clusterInfo *cephclient.ClusterInfo, request reconcile.Request, poolFailureDomain string) ([]string, []string, []string, error) {
 	osdDeploymentList := &appsv1.DeploymentList{}
 	namespaceListOpts := client.InNamespace(request.Namespace)
 	topologyLocationLabel := fmt.Sprintf(osd.TopologyLocationLabel, poolFailureDomain)
 	err := r.client.List(context.TODO(), osdDeploymentList, client.MatchingLabels{k8sutil.AppAttr: osd.AppName}, namespaceListOpts)
 	if err != nil {
-		return []string{}, []string{}, errors.Wrap(err, "failed to list osd deployments")
+		return nil, nil, nil, errors.Wrap(err, "failed to list osd deployments")
 	}
 
 	allFailureDomains := sets.NewString()
-	drainingFailureDomains := sets.NewString()
+	nodeDrainFailureDomains := sets.NewString()
+	osdDownFailureDomains := sets.NewString()
 
 	for _, deployment := range osdDeploymentList.Items {
 		labels := deployment.Spec.Template.ObjectMeta.GetLabels()
 		failureDomainName := labels[topologyLocationLabel]
 		if failureDomainName == "" {
-			return []string{}, []string{}, errors.Errorf("failed to get the topology location label %q in OSD deployment %q",
+			return nil, nil, nil, errors.Errorf("failed to get the topology location label %q in OSD deployment %q",
 				topologyLocationLabel, deployment.Name)
 		}
 
+		// Assume node drain if osd deployment ReadyReplicas count is 0 and OSD pod is not scheduled on a node
 		if deployment.Status.ReadyReplicas < 1 {
-			if !drainingFailureDomains.Has(failureDomainName) {
-				drainingFailureDomains.Insert(failureDomainName)
+			if !osdDownFailureDomains.Has(failureDomainName) {
+				osdDownFailureDomains.Insert(failureDomainName)
 			}
-		} else {
-			if !allFailureDomains.Has(failureDomainName) {
-				allFailureDomains.Insert(failureDomainName)
+			isDrained, err := hasOSDNodeDrained(r.client, request.Namespace, labels[osd.OsdIdLabelKey])
+			if err != nil {
+				return nil, nil, nil, errors.Wrapf(err, "failed to check if osd %q node is drained", deployment.Name)
+			}
+			if isDrained {
+				logger.Infof("osd %q is down and a possible node drain is detected", deployment.Name)
+				if !nodeDrainFailureDomains.Has(failureDomainName) {
+					nodeDrainFailureDomains.Insert(failureDomainName)
+				}
+			} else {
+				logger.Infof("osd %q is down but no node drain is detected", deployment.Name)
 			}
 		}
+
+		if !allFailureDomains.Has(failureDomainName) {
+			allFailureDomains.Insert(failureDomainName)
+		}
 	}
-	return allFailureDomains.List(), drainingFailureDomains.List(), nil
+	return allFailureDomains.List(), nodeDrainFailureDomains.List(), osdDownFailureDomains.List(), nil
 }
 
 func (r *ReconcileClusterDisruption) hasPGHealthCheckTimedout(pdbStateMap *corev1.ConfigMap) bool {
@@ -435,6 +476,74 @@ func (r *ReconcileClusterDisruption) hasPGHealthCheckTimedout(pdbStateMap *corev
 	return false
 }
 
+// hasNodeDrained returns true if OSD pod is not assigned to any node or if the OSD node is not schedulable
+func hasOSDNodeDrained(c client.Client, namespace, osdID string) (bool, error) {
+	osdNodeName, err := getOSDNodeName(c, namespace, osdID)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get node name assigned to OSD %q POD", osdID)
+	}
+
+	if osdNodeName == "" {
+		logger.Debugf("osd %q POD is not assigned to any node. assuming node drain", osdID)
+		return true, nil
+	}
+
+	node, err := getNode(c, osdNodeName)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get node assigned to OSD %q POD", osdID)
+	}
+	return node.Spec.Unschedulable, nil
+}
+
+func getOSDNodeName(c client.Client, namespace, osdID string) (string, error) {
+	pods := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{osd.OsdIdLabelKey: osdID},
+	}
+
+	err := c.List(context.TODO(), pods, listOpts...)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to list pods for osd %q", osdID)
+	}
+
+	if len(pods.Items) > 0 {
+		return pods.Items[0].Spec.NodeName, nil
+	}
+	return "", nil
+}
+
+func getNode(c client.Client, nodeName string) (*corev1.Node, error) {
+	node := &corev1.Node{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get node %q", nodeName)
+	}
+	return node, nil
+}
+
 func getPDBName(failureDomainType, failureDomainName string) string {
 	return k8sutil.TruncateNodeName(fmt.Sprintf("%s-%s-%s", osdPDBAppName, failureDomainType, "%s"), failureDomainName)
+}
+
+func getLastDrainTimeStamp(pdbStateMap *corev1.ConfigMap, key string) (time.Time, error) {
+	var err error
+	var lastDrainTimeStamp time.Time
+	lastDrainTimeStampString, ok := pdbStateMap.Data[key]
+	if !ok || len(lastDrainTimeStampString) == 0 {
+		return time.Now(), nil
+	} else {
+		lastDrainTimeStamp, err = time.Parse(time.RFC3339, pdbStateMap.Data[key])
+		if err != nil {
+			return time.Time{}, errors.Wrapf(err, "failed to parse timestamp %q", pdbStateMap.Data[key])
+		}
+	}
+
+	return lastDrainTimeStamp, nil
+}
+
+func resetPDBConfig(pdbStateMap *corev1.ConfigMap) {
+	pdbStateMap.Data[drainingFailureDomainKey] = ""
+	delete(pdbStateMap.Data, drainingFailureDomainDurationKey)
+	delete(pdbStateMap.Data, pgHealthCheckDurationKey)
 }


### PR DESCRIPTION
This PR has following changes around OSD pdbs
- Detect node drains more reliably. When OSD is down and OSD pod is not scheduled to any node or if the scheduled node is not ready, then assume that node is draining.
- Don't set no-out flag on the failure domain if the OSD is down due to reasons other than node drain (say disk failure)
- update unit tests
- update design doc to reflect above changes

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit aee8f568534d50a290f5c7fb74845c1407a4934f)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves  https://bugzilla.redhat.com/show_bug.cgi?id=1950419

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
