### PR TITLE
Bug 1959983: ceph: Persist expected mon endpoints immediately during mon failover

### DIFF
--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -229,11 +229,17 @@ func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string
 	}
 
 	// Parse the max monitor id
+	storedMaxMonID := -1
 	if id, ok := cm.Data[MaxMonIDKey]; ok {
-		maxMonID, err = strconv.Atoi(id)
+		storedMaxMonID, err = strconv.Atoi(id)
 		if err != nil {
 			logger.Errorf("invalid max mon id %q. %v", id, err)
+		} else {
+			maxMonID = storedMaxMonID
 		}
+	}
+	if maxMonID != storedMaxMonID {
+		logger.Infof("updating obsolete maxMonID %d to actual value %d", storedMaxMonID, maxMonID)
 	}
 
 	// Make sure the max id is consistent with the current monitors

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -770,11 +770,21 @@ func (c *Cluster) saveMonConfig() error {
 		return errors.Wrap(err, "failed to format csi config")
 	}
 
+	maxMonID, err := c.getStoredMaxMonID()
+	if err != nil {
+		return errors.Wrap(err, "failed to save maxMonID")
+	}
+
 	configMap.Data = map[string]string{
 		EndpointDataKey: FlattenMonEndpoints(c.ClusterInfo.Monitors),
-		MaxMonIDKey:     strconv.Itoa(c.maxMonID),
-		MappingKey:      string(monMapping),
-		csi.ConfigKey:   csiConfigValue,
+		// persist the maxMonID that was previously stored in the configmap. We are likely saving info
+		// about scheduling of the mons, but we only want to update the maxMonID once a new mon has
+		// actually been started. If the operator is restarted or the reconcile is otherwise restarted,
+		// we want to calculate the mon scheduling next time based on the committed maxMonID, rather
+		// than only a mon scheduling, which may not have completed.
+		MaxMonIDKey:   maxMonID,
+		MappingKey:    string(monMapping),
+		csi.ConfigKey: csiConfigValue,
 	}
 
 	if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap); err != nil {
@@ -805,6 +815,55 @@ func (c *Cluster) saveMonConfig() error {
 		return errors.Wrap(err, "failed to update csi cluster config")
 	}
 
+	return nil
+}
+
+func (c *Cluster) getStoredMaxMonID() (string, error) {
+	configmap, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return "", errors.Wrap(err, "could not load maxMonId")
+	}
+	if err == nil {
+		if val, ok := configmap.Data[MaxMonIDKey]; ok {
+			return val, nil
+		}
+	}
+
+	// if the configmap cannot be loaded, assume a new cluster. If the mons have previously
+	// been created, the maxMonID will anyway analyze them to ensure the index is correct
+	// even if this error occurs.
+	logger.Infof("existing maxMonID not found or failed to load. %v", err)
+	return "-1", nil
+}
+
+func (c *Cluster) commitMaxMonID(monName string) error {
+	committedMonID, err := k8sutil.NameToIndex(monName)
+	if err != nil {
+		return errors.Wrapf(err, "invalid mon name %q", monName)
+	}
+
+	configmap, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to find existing mon endpoint config map")
+	}
+
+	// set the new max key if greater
+	existingMax, err := strconv.Atoi(configmap.Data[MaxMonIDKey])
+	if err != nil {
+		return errors.Wrap(err, "failed to read existing maxMonId")
+	}
+
+	if existingMax >= committedMonID {
+		logger.Infof("no need to commit maxMonID %d since it is not greater than existing maxMonID %d", committedMonID, existingMax)
+		return nil
+	}
+
+	logger.Infof("updating maxMonID from %d to %d after committing mon %q", existingMax, committedMonID, monName)
+	configmap.Data[MaxMonIDKey] = strconv.Itoa(committedMonID)
+
+	if _, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(configmap); err != nil {
+		return errors.Wrap(err, "failed to update mon endpoint config map for the maxMonID")
+	}
 	return nil
 }
 
@@ -947,6 +1006,11 @@ func (c *Cluster) startMon(m *monConfig, node *NodeInfo) error {
 	_, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(d)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create mon deployment %s", d.Name)
+	}
+
+	// Commit the maxMonID after a mon deployment has been started (and not just scheduled)
+	if err := c.commitMaxMonID(m.DaemonName); err != nil {
+		return errors.Wrapf(err, "failed to commit maxMonId after starting mon %q", m.DaemonName)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -327,11 +327,6 @@ func (c *Cluster) ensureMonsRunning(mons []*monConfig, i, targetCount int, requi
 		return errors.Wrap(err, "failed to save mons")
 	}
 
-	// make sure we have the connection info generated so connections can happen
-	if err := WriteConnectionConfig(c.context, c.ClusterInfo); err != nil {
-		return err
-	}
-
 	// Start the deployment
 	if err := c.startDeployments(mons[0:expectedMonCount], requireAllInQuorum); err != nil {
 		return errors.Wrap(err, "failed to start mon pods")
@@ -751,6 +746,29 @@ func (c *Cluster) waitForMonsToJoin(mons []*monConfig, requireAllInQuorum bool) 
 }
 
 func (c *Cluster) saveMonConfig() error {
+	if err := c.persistExpectedMonDaemons(); err != nil {
+		return errors.Wrap(err, "failed to persist expected mons")
+	}
+
+	// Every time the mon config is updated, must also update the global config so that all daemons
+	// have the most updated version if they restart.
+	if err := config.GetStore(c.context, c.Namespace, &c.ownerRef).CreateOrUpdate(c.ClusterInfo); err != nil {
+		return errors.Wrap(err, "failed to update the global config")
+	}
+
+	// write the latest config to the config dir
+	if err := WriteConnectionConfig(c.context, c.ClusterInfo); err != nil {
+		return errors.Wrap(err, "failed to write connection config for new mons")
+	}
+
+	if err := csi.SaveClusterConfig(c.context.Clientset, c.Namespace, c.ClusterInfo, c.csiConfigMutex); err != nil {
+		return errors.Wrap(err, "failed to update csi cluster config")
+	}
+
+	return nil
+}
+
+func (c *Cluster) persistExpectedMonDaemons() error {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      EndpointConfigMapName,
@@ -758,7 +776,6 @@ func (c *Cluster) saveMonConfig() error {
 		},
 	}
 	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
-
 	monMapping, err := json.Marshal(c.mapping)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal mon mapping")
@@ -797,24 +814,7 @@ func (c *Cluster) saveMonConfig() error {
 			return errors.Wrap(err, "failed to update mon endpoint config map")
 		}
 	}
-
 	logger.Infof("saved mon endpoints to config map %+v", configMap.Data)
-
-	// Every time the mon config is updated, must also update the global config so that all daemons
-	// have the most updated version if they restart.
-	if err := config.GetStore(c.context, c.Namespace, &c.ownerRef).CreateOrUpdate(c.ClusterInfo); err != nil {
-		return errors.Wrap(err, "failed to update the global config")
-	}
-
-	// write the latest config to the config dir
-	if err := WriteConnectionConfig(c.context, c.ClusterInfo); err != nil {
-		return errors.Wrap(err, "failed to write connection config for new mons")
-	}
-
-	if err := csi.SaveClusterConfig(c.context.Clientset, c.Namespace, c.ClusterInfo, c.csiConfigMutex); err != nil {
-		return errors.Wrap(err, "failed to update csi cluster config")
-	}
-
 	return nil
 }
 
@@ -1011,6 +1011,12 @@ func (c *Cluster) startMon(m *monConfig, node *NodeInfo) error {
 	// Commit the maxMonID after a mon deployment has been started (and not just scheduled)
 	if err := c.commitMaxMonID(m.DaemonName); err != nil {
 		return errors.Wrapf(err, "failed to commit maxMonId after starting mon %q", m.DaemonName)
+	}
+
+	// Persist the expected list of mons to the configmap in case the operator is interrupted before the mon failover is completed
+	// The config on disk won't be updated until the mon failover is completed
+	if err := c.persistExpectedMonDaemons(); err != nil {
+		return errors.Wrap(err, "failed to persist expected mon daemons")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -34,6 +34,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/test"
@@ -228,6 +229,30 @@ func validateStart(t *testing.T, c *Cluster) {
 	// there is only one pod created. the other two won't be created since the first one doesn't start
 	_, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Get("rook-ceph-mon-a", metav1.GetOptions{})
 	assert.Nil(t, err)
+}
+
+func TestPersistMons(t *testing.T) {
+	clientset := test.New(t, 1)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
+
+	// Persist mon a
+	err := c.persistExpectedMonDaemons()
+	assert.NoError(t, err)
+
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "a=1.2.3.1:6789", cm.Data[EndpointDataKey])
+
+	// Persist mon b, and remove mon a for simply testing the configmap is updated
+	c.ClusterInfo.Monitors["b"] = &cephclient.MonInfo{Name: "b", Endpoint: "4.5.6.7:3300"}
+	delete(c.ClusterInfo.Monitors, "a")
+	err = c.persistExpectedMonDaemons()
+	assert.NoError(t, err)
+
+	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "b=4.5.6.7:3300", cm.Data[EndpointDataKey])
 }
 
 func TestSaveMonEndpoints(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
After mon failover is initiated, there was a time window where if the operator
was restarted, the new mon is started and has joined quorum, but the operator
does not believe the mon should be in quorum after the operator restart.
The operator was mistakenly removing the extra mon prematurely, sometimes
causing quorum to be lost if another mon was also down at the same time.
If the mon does not come back online, steps to recover quroum would need
to be followed from the disaster guide. Now the expected list of mons
will be updated immediately during mon failover if the operator successfully
created the new mon deployment, thus removing the window where restarting
the operator can cause quorum loss.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1959983

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
