### PR TITLE
bug 1959976: ceph: retry once before mon failover if mon pod is unscheduled

### DIFF
--- a/Documentation/ceph-mon-health.md
+++ b/Documentation/ceph-mon-health.md
@@ -78,6 +78,11 @@ If you want to force a mon to failover for testing or other purposes, you can sc
 for the timeout. Note that the operator may scale up the mon again automatically if the operator is restarted or if a full
 reconcile is triggered, such as when the CephCluster CR is updated.
 
+If the mon pod is in pending state and couldn't be assigned to a node (say, due to node drain), then the operator will wait for the timeout again before the mon failover. So the timeout waiting for the mon failover will be doubled in this case.
+
+To disable monitor automatic failover, the `timeout` can be set to `0`, if the monitor goes out of quorum Rook will never fail it over onto another node.
+This is especially useful for planned maintenance.
+
 ### Example Failover
 
 Rook will create mons with pod names such as mon-a, mon-b, and mon-c. Let's say mon-b had an issue and the pod failed.

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -37,7 +37,10 @@ var (
 	// HealthCheckInterval is the interval to check if the mons are in quorum
 	HealthCheckInterval = 45 * time.Second
 	// MonOutTimeout is the duration to wait before removing/failover to a new mon pod
-	MonOutTimeout = 600 * time.Second
+	MonOutTimeout = 10 * time.Minute
+
+	retriesBeforeNodeDrainFailover = 1
+	timeZero                       = time.Duration(0)
 )
 
 // HealthChecker aggregates the mon/cluster info needed to check the health of the monitors
@@ -189,6 +192,19 @@ func (c *Cluster) checkHealth() error {
 
 			continue
 		}
+
+		// retry only once before the mon failover if the mon pod is not scheduled
+		monLabelSelector := fmt.Sprintf("%s=%s,%s=%s", k8sutil.AppAttr, AppName, "ceph_daemon_id", mon.Name)
+		isScheduled, err := k8sutil.IsPodScheduled(c.context.Clientset, c.Namespace, monLabelSelector)
+		if err != nil {
+			logger.Warningf("failed to check if mon %q is assigned to a node, continuing with mon failover. %v", mon.Name, err)
+		} else if !isScheduled && retriesBeforeNodeDrainFailover > 0 {
+			logger.Warningf("mon %q NOT found in quorum after timeout. Mon pod is not scheduled. Retrying with a timeout of %.2f seconds before failover", mon.Name, MonOutTimeout.Seconds())
+			delete(c.monTimeoutList, mon.Name)
+			retriesBeforeNodeDrainFailover = retriesBeforeNodeDrainFailover - 1
+			return nil
+		}
+		retriesBeforeNodeDrainFailover = 1
 
 		logger.Warningf("mon %q NOT found in quorum and timeout exceeded, mon will be failed over", mon.Name)
 		c.failMon(len(quorumStatus.MonMap.Mons), desiredMonCount, mon.Name)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -410,3 +410,21 @@ func removeDuplicateEnvVarsFromContainer(container *v1.Container) {
 	}
 	container.Env = vars
 }
+
+func IsPodScheduled(clientSet kubernetes.Interface, namespace, selector string) (bool, error) {
+	listOpts := metav1.ListOptions{LabelSelector: selector}
+	podList, err := clientSet.CoreV1().Pods(namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to list pods with label selector %q in namespace %q", selector, namespace)
+	}
+
+	if len(podList.Items) == 0 {
+		return false, errors.Errorf("no pods found with label selector %q in namespace %q", selector, namespace)
+	}
+
+	if podList.Items[0].Spec.NodeName == "" {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
Events like node drain can take more than 10-15 minutes. If the node is not up before the default monTimeOut of 10 minutes, then rook will attempt to fail over the mon. This failover won't work as the node is still down.
This PR retries once before the mon failover if the mon pod is not scheduled

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit f38829b57d0c14e28a203a8b7dd4325036d03eaf)
(cherry picked from commit 11e1d7d1ca0fbd623c6d7c23dc53c7e1e07e0e28)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
