### PR TITLE
Bug 1949165: Set the location on the mon daemon for stretch clusters to reenable mon failover

### DIFF
--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -17,7 +17,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"syscall"
 
@@ -130,19 +129,6 @@ func CreateDefaultStretchCrushRule(context *clusterd.Context, clusterInfo *Clust
 		return errors.Wrap(err, "failed to create default stretch crush rule")
 	}
 	logger.Info("successfully created the default stretch crush rule")
-	return nil
-}
-
-// SetMonStretchZone sets the location of a mon in the stretch cluster
-func SetMonStretchZone(context *clusterd.Context, clusterInfo *ClusterInfo, monName, failureDomain, zone string) error {
-	args := []string{"mon", "set_location", monName, fmt.Sprintf("%s=%s", failureDomain, zone)}
-	buf, err := NewCephCommand(context, clusterInfo, args).Run()
-	if err != nil {
-		return errors.Wrap(err, "failed to set mon stretch zone")
-	}
-	output := string(buf)
-	logger.Debug(output)
-	logger.Infof("successfully set mon %q stretch zone to %q", monName, zone)
 	return nil
 }
 

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -82,28 +82,6 @@ func TestStretchElectionStrategy(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestStretchClusterSettings(t *testing.T) {
-	monName := "a"
-	failureDomain := "rack"
-	zone := "rack-x"
-	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
-		logger.Infof("Command: %s %v", command, args)
-		switch {
-		case args[0] == "mon" && args[1] == "set_location":
-			assert.Equal(t, monName, args[2])
-			assert.Equal(t, fmt.Sprintf("%s=%s", failureDomain, zone), args[3])
-			return "", nil
-		}
-		return "", errors.Errorf("unexpected ceph command %q", args)
-	}
-	context := &clusterd.Context{Executor: executor}
-	clusterInfo := AdminClusterInfo("mycluster")
-
-	err := SetMonStretchZone(context, clusterInfo, monName, failureDomain, zone)
-	assert.NoError(t, err)
-}
-
 func TestStretchClusterMonTiebreaker(t *testing.T) {
 	monName := "a"
 	failureDomain := "rack"

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -417,14 +417,7 @@ func (c *Cluster) failoverMon(name string) error {
 
 	// Assign to a zone if a stretch cluster
 	if c.spec.IsStretchCluster() {
-		updateArbiter := false
 		if name == c.arbiterMon {
-			updateArbiter = true
-		}
-		if err := c.assignStretchMonsToZones([]*monConfig{m}); err != nil {
-			return errors.Wrap(err, "failed to assign mons to zones")
-		}
-		if updateArbiter {
 			// Update the arbiter mon for the stretch cluster if it changed
 			if err := c.ConfigureArbiter(); err != nil {
 				return errors.Wrap(err, "failed to configure stretch arbiter")

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -310,10 +310,6 @@ func (c *Cluster) startMons(targetCount int) error {
 }
 
 func (c *Cluster) configureStretchCluster(mons []*monConfig) error {
-	if err := c.assignStretchMonsToZones(mons); err != nil {
-		return errors.Wrap(err, "failed to assign mons to zones")
-	}
-
 	// Enable the mon connectivity strategy
 	if err := cephclient.EnableStretchElectionStrategy(c.context, c.ClusterInfo); err != nil {
 		return errors.Wrap(err, "failed to enable stretch cluster")
@@ -341,45 +337,6 @@ func (c *Cluster) isArbiterZone(zone string) bool {
 		return false
 	}
 	return c.getArbiterZone() == zone
-}
-
-func (c *Cluster) assignStretchMonsToZones(mons []*monConfig) error {
-	arbiterZone := c.getArbiterZone()
-
-	// Get the mon dump to see if the zones are already applied to the mons
-	monDump, err := cephclient.GetMonDump(c.context, c.ClusterInfo)
-	if err != nil {
-		return errors.Wrap(err, "failed to detect if stretch mons are already assigned to zones")
-	}
-
-	// Set the location for each mon
-	domainName := c.stretchFailureDomainName()
-	for _, mon := range mons {
-		if mon.Zone == arbiterZone {
-			// remember the arbiter mon to be set later in the reconcile after the OSDs are configured
-			c.arbiterMon = mon.DaemonName
-		}
-		// Check if the zone is already set on the mon
-		alreadySet := false
-		for _, monInfo := range monDump.Mons {
-			if monInfo.Name == mon.DaemonName {
-				desiredLocation := fmt.Sprintf("{%s=%s}", domainName, mon.Zone)
-				if monInfo.CrushLocation == desiredLocation {
-					alreadySet = true
-				}
-				break
-			}
-		}
-		if alreadySet {
-			logger.Infof("mon %q stretch domain %q is already set to %q", mon.DaemonName, domainName, mon.Zone)
-			continue
-		}
-		logger.Infof("setting mon %q to stretch %s=%s", mon.DaemonName, domainName, mon.Zone)
-		if err := cephclient.SetMonStretchZone(c.context, c.ClusterInfo, mon.DaemonName, domainName, mon.Zone); err != nil {
-			return errors.Wrapf(err, "failed to set mon %q zone", mon.DaemonName)
-		}
-	}
-	return nil
 }
 
 func (c *Cluster) ConfigureArbiter() error {

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -317,6 +317,15 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 		WorkingDir:    config.VarLogCephDir,
 	}
 
+	if monConfig.Zone != "" {
+		desiredLocation := fmt.Sprintf("%s=%s", c.stretchFailureDomainName(), monConfig.Zone)
+		container.Args = append(container.Args, []string{"--set-crush-location", desiredLocation}...)
+		if monConfig.Zone == c.getArbiterZone() {
+			// remember the arbiter mon to be set later in the reconcile after the OSDs are configured
+			c.arbiterMon = monConfig.DaemonName
+		}
+	}
+
 	// If the liveness probe is enabled
 	container = config.ConfigureLivenessProbe(cephv1.KeyMon, container, c.spec.HealthCheck)
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mon daemon in a stretch cluster now can have its location set as a CLI param instead of setting it with a separate command. This enables mon failover to set the location of a mon immediately when it is joining quorum instead of having a delayed command to set the location.

This is merging before the upstream PR https://github.com/rook/rook/pull/7535 since upstream needs to wait for `ceph/ceph:v16.2.5`.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1949165

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
