### PR TITLE
Bug 1925369: ceph: mons should enable v1 address type when enabling v2

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -312,6 +312,14 @@ class RadosJSON:
         if len(q_leader_matching_list) == 0:
             raise ExecutionFailureException("No matching 'mon' details found")
         q_leader_details = q_leader_matching_list[0]
+        # get the address vector of the quorum-leader
+        q_leader_addrvec = q_leader_details.get('public_addrs', {}).get('addrvec', [])
+        # if the quorum-leader has only one address in the address-vector
+        # and it is of type 'v2' (ie; with <IP>:3300),
+        # raise an exception to make user aware that
+        # they have to enable 'v1' (ie; with <IP>:6789) type as well
+        if len(q_leader_addrvec) == 1 and q_leader_addrvec[0]['type'] == 'v2':
+            raise ExecutionFailureException("Only 'v2' address type is enabled, user should also enable 'v1' type as well")
         ip_port = str(q_leader_details['public_addr'].split('/')[0])
         return "{}={}".format(str(q_leader_name), ip_port)
 


### PR DESCRIPTION
Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>
(cherry picked from commit 7445afb8748349445ac774e453f9b9cd31a10de1)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
