### PR TITLE
Bug 1970583: Fix vault when used with kv version 2

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -160,66 +160,61 @@ set -e
 
 KEK_NAME=%s
 KEY_PATH=%s
-VAULT_DEFAULT_BACKEND=v1
 CURL_PAYLOAD=$(mktemp)
 ARGS=(--silent --show-error --request GET --header "X-Vault-Token: ${VAULT_TOKEN}")
+PYTHON_DATA_PARSE="['data']"
 
 # If a vault namespace is set
 if [ -n "$VAULT_NAMESPACE" ]; then
-	ARGS+=(--header "X-Vault-Namespace: ${VAULT_NAMESPACE}")
+  ARGS+=(--header "X-Vault-Namespace: ${VAULT_NAMESPACE}")
 fi
 
 # If SSL is configured but self-signed CA is used
 if [ -n "$VAULT_SKIP_VERIFY" ] && [[ "$VAULT_SKIP_VERIFY" == "true" ]]; then
-	ARGS+=(--insecure)
+  ARGS+=(--insecure)
 fi
 
 # TLS args
 if [ -n "$VAULT_CACERT" ]; then
-	ARGS+=(--capath $(dirname "${VAULT_CACERT}"))
+  ARGS+=(--capath $(dirname "${VAULT_CACERT}"))
 fi
 if [ -n "$VAULT_CLIENT_CERT" ]; then
-	ARGS+=(--cert "${VAULT_CLIENT_CERT}")
+  ARGS+=(--cert "${VAULT_CLIENT_CERT}")
 fi
 if [ -n "$VAULT_CLIENT_KEY" ]; then
-	ARGS+=(--key "${VAULT_CLIENT_KEY}")
+  ARGS+=(--key "${VAULT_CLIENT_KEY}")
 fi
 
-# For a request to any host/port, connect to VAULT_TLS_SERVER_NAME:request's original port instead
+# For a request to any host/port, connect to VAULT_TLS_SERVER_NAME:requests original port instead
 # Used for SNI validation and correct certificate matching
 if [ -n "$VAULT_TLS_SERVER_NAME" ]; then
-	ARGS+=(--connect-to ::"${VAULT_TLS_SERVER_NAME}":)
+  ARGS+=(--connect-to ::"${VAULT_TLS_SERVER_NAME}":)
 fi
 
-# Check KV backend
-if [ -z "$VAULT_BACKEND" ]; then
-	VAULT_BACKEND=$VAULT_DEFAULT_BACKEND
+# Check KV engine version
+if [[ "$VAULT_BACKEND" == "v2" ]]; then
+  PYTHON_DATA_PARSE="['data']['data']"
+  VAULT_BACKEND_PATH="$VAULT_BACKEND_PATH/data"
 fi
-
-# trim VAULT_BACKEND_PATH for last character '/' to avoid a redirect response from the server
-VAULT_BACKEND_PATH="${VAULT_BACKEND_PATH%%/}"
 
 # Get the Key Encryption Key
-curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_BACKEND"/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
+curl "${ARGS[@]}" "$VAULT_ADDR"/v1/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
 
 # Check for warnings in the payload
 if python3 -c "import sys, json; print(json.load(sys.stdin)[\"warnings\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
-	# We could get a warning but it is not necessary an issue, so if there is no key we exit
-	if ! python3 -c "import sys, json; print(json.load(sys.stdin)[\"data\"][\"$KEK_NAME\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
-		exit 1
-	fi
+  # We could get a warning but it is not necessary an issue, so if there is no key we exit
+  if ! python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
+    exit 1
+  fi
 fi
 
 # Check for errors in the payload
 if python3 -c "import sys, json; print(json.load(sys.stdin)[\"errors\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
-	exit 1
+  exit 1
 fi
 
 # Put the KEK in a file for cryptsetup to read
-python3 -c "import sys, json; print(json.load(sys.stdin)[\"data\"][\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
-
-# purge payload file
-rm -f "$CURL_PAYLOAD"
+python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
 `
 
 	// If the disk identifier changes (different major and minor) we must force copy


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The API path when the KV enfine is used in version is different and must be adapted. We need to append a 'data' path, thus the path and response are changing.

v1 is https://vault.local.com:8200/v1/test-kv1/key
v2 is https://vault.local.com:8200/v1/test-kv2/data/key

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1970583

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
