### PR TITLE
Bug 1964025: ceph: enable snap schedule for downstream nautilus

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -275,7 +275,7 @@ func setCommonPoolProperties(context *clusterd.Context, clusterInfo *ClusterInfo
 		}
 
 		// Schedule snapshots
-		if pool.Mirroring.SnapshotSchedulesEnabled() && clusterInfo.CephVersion.IsAtLeastOctopus() {
+		if pool.Mirroring.SnapshotSchedulesEnabled() && clusterInfo.CephVersion.IsAtLeastNautilus() {
 			err = enableSnapshotSchedules(context, clusterInfo, pool, poolName)
 			if err != nil {
 				return errors.Wrapf(err, "failed to enable snapshot scheduling for pool %q", poolName)


### PR DESCRIPTION
Downstream nautilus has the code for rbd mirroring snapshots schedule so we need to enable it.

The same downstream patch was done for 4.7 #194 as we are still using Nautilus in 4.8 enabling snapshot scheduling for the same reason.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

