### PR TITLE
Bug 1966139: ceph: add osd slow ops alert

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -175,6 +175,18 @@ spec:
       for: 1m
       labels:
         severity: critical
+    - alert: CephOSDSlowOps
+      annotations:
+        description: '{{ $value }} Ceph OSD requests are taking too long to process.
+          Please check ceph status to find out the cause.'
+        message: OSD requests are taking too long to process.
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        ceph_healthcheck_slow_ops > 0
+      for: 30s
+      labels:
+        severity: warning
     - alert: CephDataRecoveryTakingTooLong
       annotations:
         description: Data recovery has been active for too long. Contact Support.


### PR DESCRIPTION
This PR adds an alert that notifies the users about OSD
requests taking too long to process.

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves # https://bugzilla.redhat.com/show_bug.cgi?id=1966139

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
