### PR TITLE
Bug 1974399: ceph: use cacert if no client cert/key are present

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -176,7 +176,11 @@ fi
 
 # TLS args
 if [ -n "$VAULT_CACERT" ]; then
-  ARGS+=(--capath $(dirname "${VAULT_CACERT}"))
+  if [ -z "$VAULT_CLIENT_CERT" ] && [ -z "$VAULT_CLIENT_KEY" ]; then
+    ARGS+=(--cacert "${VAULT_CACERT}")
+  else
+    ARGS+=(--capath $(dirname "${VAULT_CACERT}"))
+  fi
 fi
 if [ -n "$VAULT_CLIENT_CERT" ]; then
   ARGS+=(--cert "${VAULT_CLIENT_CERT}")
@@ -215,6 +219,9 @@ fi
 
 # Put the KEK in a file for cryptsetup to read
 python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
+
+# purge payload file
+rm -f "$CURL_PAYLOAD"
 `
 
 	// If the disk identifier changes (different major and minor) we must force copy


### PR DESCRIPTION
We have seen issues with fullchain.pem files containing one self-signed
certificate. At the same time, the failing configuration was not
providing any client certificates or keys.

The error from curl was `"self signed certificate in the chain"`.

The openssl binary is not available so we cannot even c_rehash the
certificate directory when using `--capath`, however this worked already
with a fully signed fullchain.pem along with a client certificate and
key. So we cannot only use `--cacert` which will break that use case.

This is becoming really obscur on why using `--cacert` solves this
problem. I just can't wait to use the `vault` binary, that's all I can
say...

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit eb0c986196833a63ea98692bd7a3925c93179bf8)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
