### PR TITLE
Bug 1974477: Disable insecure global id if no insecure clients

### DIFF
--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -270,3 +270,31 @@ func PopulateMonHostMembers(monitors map[string]*MonInfo) ([]string, []string) {
 
 	return monMembers, monHosts
 }
+
+// SetConfig applies a setting for a single mgr daemon
+func SetConfig(context *clusterd.Context, clusterInfo *ClusterInfo, daemonID string, key, val string, force bool) (bool, error) {
+	var getArgs, setArgs []string
+	getArgs = append(getArgs, "config", "get", daemonID, key)
+	if val == "" {
+		setArgs = append(setArgs, "config", "rm", daemonID, key)
+	} else {
+		setArgs = append(setArgs, "config", "set", daemonID, key, val)
+	}
+	if force {
+		setArgs = append(setArgs, "--force")
+	}
+
+	// Retrieve previous value to monitor changes
+	var prevVal string
+	buf, err := NewCephCommand(context, clusterInfo, getArgs).Run()
+	if err == nil {
+		prevVal = strings.TrimSpace(string(buf))
+	}
+
+	if _, err := NewCephCommand(context, clusterInfo, setArgs).Run(); err != nil {
+		return false, errors.Wrapf(err, "failed to set config key %s to %q", key, val)
+	}
+
+	hasChanged := prevVal != val
+	return hasChanged, nil
+}

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -17,8 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -59,35 +57,6 @@ func MgrDisableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name 
 		return enableDisableBalancerModule(context, clusterInfo, "off")
 	}
 	return enableModule(context, clusterInfo, name, false, "disable")
-}
-
-// MgrSetConfig applies a setting for a single mgr daemon
-func MgrSetConfig(context *clusterd.Context, clusterInfo *ClusterInfo, mgrName string, key, val string, force bool) (bool, error) {
-	var getArgs, setArgs []string
-	mgrID := fmt.Sprintf("mgr.%s", mgrName)
-	getArgs = append(getArgs, "config", "get", mgrID, key)
-	if val == "" {
-		setArgs = append(setArgs, "config", "rm", mgrID, key)
-	} else {
-		setArgs = append(setArgs, "config", "set", mgrID, key, val)
-	}
-	if force {
-		setArgs = append(setArgs, "--force")
-	}
-
-	// Retrieve previous value to monitor changes
-	var prevVal string
-	buf, err := NewCephCommand(context, clusterInfo, getArgs).Run()
-	if err == nil {
-		prevVal = strings.TrimSpace(string(buf))
-	}
-
-	if _, err := NewCephCommand(context, clusterInfo, setArgs).Run(); err != nil {
-		return false, errors.Wrapf(err, "failed to set mgr config key %s to \"%s\"", key, val)
-	}
-
-	hasChanged := prevVal != val
-	return hasChanged, nil
 }
 
 func enableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name string, force bool, action string) error {

--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -132,6 +132,29 @@ func (c *cephStatusChecker) checkStatus() {
 			logger.Errorf("failed to delete pod on not ready nodes. %v", err)
 		}
 	}
+
+	c.configureHealthSettings(status)
+}
+
+func (c *cephStatusChecker) configureHealthSettings(status cephclient.CephStatus) {
+	// loop through the health codes and log what we find
+	for healthCode, check := range status.Health.Checks {
+		logger.Debugf("Health: %q, code: %q, message: %q", check.Severity, healthCode, check.Summary.Message)
+	}
+
+	// disable the insecure global id if there are no old clients
+	if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED"]; ok {
+		if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM"]; !ok {
+			logger.Info("Disabling the insecure global ID as no legacy clients are currently connected. If you still require the insecure connections, see the CVE to suppress the health warning and re-enable the insecure connections. https://docs.ceph.com/en/latest/security/CVE-2021-20288/")
+			if _, err := cephclient.SetConfig(c.context, c.clusterInfo, "mon", "auth_allow_insecure_global_id_reclaim", "false", false); err != nil {
+				logger.Warningf("failed to disable the insecure global ID. %v", err)
+			} else {
+				logger.Info("insecure global ID is now disabled")
+			}
+		} else {
+			logger.Warning("insecure clients are connected to the cluster, to resolve the AUTH_INSECURE_GLOBAL_ID_RECLAIM health warning please refer to the upgrade guide to ensure all Ceph daemons are updated.")
+		}
+	}
 }
 
 // updateStatus updates an object with a given status

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -25,11 +25,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	optest "github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -201,6 +203,98 @@ func Test_cephStatusChecker_conditionMessageReason(t *testing.T) {
 			if got2 != tt.want2 {
 				t.Errorf("cephStatusChecker.conditionMessageReason() got2 = %v, want %v", got2, tt.want2)
 			}
+
+		})
+	}
+}
+
+func TestConfigureHealthSettings(t *testing.T) {
+	c := &cephStatusChecker{
+		context:     &clusterd.Context{},
+		clusterInfo: cephclient.AdminClusterInfo("ns"),
+	}
+	getGlobalIDReclaim := false
+	setGlobalIDReclaim := false
+	c.context.Executor = &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+			logger.Infof("Command: %s %v", command, args)
+			if args[0] == "config" && args[3] == "auth_allow_insecure_global_id_reclaim" {
+				if args[1] == "get" {
+					getGlobalIDReclaim = true
+					return "", nil
+				}
+				if args[1] == "set" {
+					setGlobalIDReclaim = true
+					return "", nil
+				}
+			}
+			return "", errors.New("mock error to simulate failure of SetConfig() function")
+		},
+	}
+	noActionOneWarningStatus := cephclient.CephStatus{
+		Health: cephclient.HealthStatus{
+			Checks: map[string]cephclient.CheckMessage{
+				"MDS_ALL_DOWN": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "MDS_ALL_DOWN",
+					},
+				},
+			},
+		},
+	}
+	disableInsecureGlobalIDStatus := cephclient.CephStatus{
+		Health: cephclient.HealthStatus{
+			Checks: map[string]cephclient.CheckMessage{
+				"AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "foo",
+					},
+				},
+			},
+		},
+	}
+	noDisableInsecureGlobalIDStatus := cephclient.CephStatus{
+		Health: cephclient.HealthStatus{
+			Checks: map[string]cephclient.CheckMessage{
+				"AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "foo",
+					},
+				},
+				"AUTH_INSECURE_GLOBAL_ID_RECLAIM": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "bar",
+					},
+				},
+			},
+		},
+	}
+
+	type args struct {
+		status                     cephclient.CephStatus
+		expectedGetGlobalIDSetting bool
+		expectedSetGlobalIDSetting bool
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"no-warnings", args{cephclient.CephStatus{}, false, false}},
+		{"no-action-one-warning", args{noActionOneWarningStatus, false, false}},
+		{"disable-insecure-global-id", args{disableInsecureGlobalIDStatus, true, true}},
+		{"no-disable-insecure-global-id", args{noDisableInsecureGlobalIDStatus, false, false}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getGlobalIDReclaim = false
+			setGlobalIDReclaim = false
+			c.configureHealthSettings(tt.args.status)
+			assert.Equal(t, tt.args.expectedGetGlobalIDSetting, getGlobalIDReclaim)
+			assert.Equal(t, tt.args.expectedSetGlobalIDSetting, setGlobalIDReclaim)
 		})
 	}
 }

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -20,6 +20,7 @@ package mgr
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"strconv"
 	"syscall"
 	"time"
@@ -119,15 +120,17 @@ func (c *Cluster) configureDashboardModules() error {
 }
 
 func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error) {
+	daemonID = fmt.Sprintf("mgr.%s", daemonID)
+
 	// url prefix
-	hasChanged, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/url_prefix", c.spec.Dashboard.UrlPrefix, false)
+	hasChanged, err := client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/url_prefix", c.spec.Dashboard.UrlPrefix, false)
 	if err != nil {
 		return false, err
 	}
 
 	// ssl support
 	ssl := strconv.FormatBool(c.spec.Dashboard.SSL)
-	changed, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl", ssl, false)
+	changed, err := client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl", ssl, false)
 	if err != nil {
 		return false, err
 	}
@@ -135,7 +138,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// server port
 	port := strconv.Itoa(c.dashboardPort())
-	changed, err = client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/server_port", port, false)
+	changed, err = client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/server_port", port, false)
 	if err != nil {
 		return false, err
 	}
@@ -143,7 +146,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// SSL enabled. Needed to set specifically the ssl port setting
 	if c.spec.Dashboard.SSL {
-		changed, err = client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl_server_port", port, false)
+		changed, err = client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl_server_port", port, false)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -148,14 +148,15 @@ func (c *Cluster) clearHTTPBindFix() error {
 			// there are two forms of the configuration key that might exist which
 			// depends not on the current version, but on the version that may be
 			// the version being upgraded from.
-			if _, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID,
+			daemonID = fmt.Sprintf("mgr.%s", daemonID)
+			if _, err := client.SetConfig(c.context, c.clusterInfo, daemonID,
 				fmt.Sprintf("mgr/%s/server_addr", module), "", false); err != nil {
 				return errors.Wrap(err, "failed to set config for an mgr daemon using v2 format")
 			}
 
 			// this is for the format used in v1.0
 			// https://github.com/rook/rook/commit/11d318fb2f77a6ac9a8f2b9be42c826d3b4a93c3
-			if _, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID,
+			if _, err := client.SetConfig(c.context, c.clusterInfo, daemonID,
 				fmt.Sprintf("mgr/%s/%s/server_addr", module, daemonID), "", false); err != nil {
 				return errors.Wrap(err, "failed to set config for an mgr daemon using v1 format")
 			}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -352,7 +352,7 @@ func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient
 		}
 	}
 	logger.Debugf("RBD per-image IO statistics will be collected for pools: %v", enableStatsForPools)
-	_, err = cephclient.MgrSetConfig(clusterContext, clusterInfo, "", "mgr/prometheus/rbd_stats_pools", strings.Join(enableStatsForPools, ","), false)
+	_, err = cephclient.SetConfig(clusterContext, clusterInfo, "mgr.", "mgr/prometheus/rbd_stats_pools", strings.Join(enableStatsForPools, ","), false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to enable rbd_stats_pools")
 	}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -440,11 +440,11 @@ func TestConfigureRBDStats(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Case 5: Two CephBlockPools with EnableRBDStats:false & EnableRBDStats:true.
-	// MgrSetConfig returns an error
+	// SetConfig returns an error
 	context.Executor = &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
-			return "", errors.Errorf("mock error to simulate failure of MgrSetConfig() function")
+			return "", errors.New("mock error to simulate failure of SetConfig() function")
 		},
 	}
 	err = configureRBDStats(context, clusterInfo)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In the latest Ceph releases starting with v16.2.1, all clients are recommended to be updated so they will have a security fix to connect with a secure global ID. A health warning will be raised if any insecure clients are connected and another health warning is raised if insecure clients are still allowed. Rook will now disable allowing the insecure clients if the health warning is not being raised to indicate that there are insecure clients still connected. This means that upgraded clusters will not have this disabled until all the daemons are updated.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1974477

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
