### PR TITLE
Bug 1970503: sort multus annotation strings when applying

### DIFF
--- a/pkg/operator/k8sutil/network.go
+++ b/pkg/operator/k8sutil/network.go
@@ -19,6 +19,7 @@ package k8sutil
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	netapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -95,6 +96,9 @@ func ApplyMultus(net rookv1.NetworkSpec, objectMeta *metav1.ObjectMeta) error {
 	if shortSyntax && jsonSyntax {
 		return fmt.Errorf("ApplyMultus: Can't mix short and JSON form")
 	}
+
+	// Sort network strings so that pods/deployments won't need updated in a loop if nothing changes
+	sort.Strings(v)
 
 	networks := strings.Join(v, ", ")
 	if jsonSyntax {

--- a/pkg/operator/k8sutil/network_test.go
+++ b/pkg/operator/k8sutil/network_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package k8sutil
 
 import (
-	"strings"
 	"testing"
 
 	netapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -26,77 +25,149 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNetwork_ApplyMultusShort(t *testing.T) {
-	net := rookv1.NetworkSpec{
-		Provider: "multus",
-		Selectors: map[string]string{
-			publicNetworkSelectorKeyName:  "macvlan@net1",
-			clusterNetworkSelectorKeyName: "macvlan@net2",
-		},
-	}
+func TestApplyMultus(t *testing.T) {
+	t.Run("short format", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			netSelectors map[string]string
+			labels       map[string]string
+			want         string
+		}{
+			{
+				name: "no applicable networks for non-osd pod",
+				netSelectors: map[string]string{
+					"unknown": "macvlan@net1",
+				},
+				want: "",
+			},
+			{
+				name: "for a non-osd pod",
+				netSelectors: map[string]string{
+					publicNetworkSelectorKeyName:  "macvlan@net1",
+					clusterNetworkSelectorKeyName: "macvlan@net2",
+				},
+				want: "macvlan@net1",
+			},
+			{
+				name: "for an osd pod",
+				netSelectors: map[string]string{
+					publicNetworkSelectorKeyName:  "macvlan@net1",
+					clusterNetworkSelectorKeyName: "macvlan@net2",
+				},
+				labels: map[string]string{"app": "rook-ceph-osd"},
+				want:   "macvlan@net1, macvlan@net2",
+			},
+			{
+				name: "for an osd pod (reverse ordering)",
+				netSelectors: map[string]string{
+					publicNetworkSelectorKeyName:  "macvlan@net2",
+					clusterNetworkSelectorKeyName: "macvlan@net1",
+				},
+				labels: map[string]string{"app": "rook-ceph-osd"},
+				want:   "macvlan@net1, macvlan@net2", // should not change the order of output
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				net := rookv1.NetworkSpec{
+					Provider:  "multus",
+					Selectors: test.netSelectors,
+				}
+				objMeta := metav1.ObjectMeta{}
+				objMeta.Labels = test.labels
+				err := ApplyMultus(net, &objMeta)
+				assert.NoError(t, err)
+				assert.Equal(t, test.want, objMeta.Annotations["k8s.v1.cni.cncf.io/networks"])
+			})
+		}
+	})
 
-	tests := []struct {
-		name   string
-		labels map[string]string
-		want   []string
-	}{
-		{
-			name: "for a non osd pod",
-			want: []string{"macvlan@net1"},
-		},
-		{
-			name:   "for an osd pod",
-			labels: map[string]string{"app": "rook-ceph-osd"},
-			want:   []string{"macvlan@net1", "macvlan@net2"},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	t.Run("JSON format", func(t *testing.T) {
+		json1 := `{"name": "macvlan", "interface": "net1"}`
+		json2 := `{"name": "macvlan", "interface": "net2"}`
+
+		t.Run("no applicable networks for non-osd pod", func(t *testing.T) {
+			net := rookv1.NetworkSpec{
+				Provider: "multus",
+				Selectors: map[string]string{
+					"server": json1,
+					"broker": json2,
+				},
+			}
 			objMeta := metav1.ObjectMeta{}
-			objMeta.Labels = test.labels
 			err := ApplyMultus(net, &objMeta)
 			assert.NoError(t, err)
-			appliedNetworksList := strings.Split(objMeta.Annotations["k8s.v1.cni.cncf.io/networks"], ", ")
-			assert.ElementsMatch(t, appliedNetworksList, test.want)
+			// non-osd pods should not get any network annotations here
+			assert.Equal(t, "[]", objMeta.Annotations["k8s.v1.cni.cncf.io/networks"])
 		})
 
-	}
-}
+		t.Run("for a non-osd pod", func(t *testing.T) {
+			net := rookv1.NetworkSpec{
+				Provider: "multus",
+				Selectors: map[string]string{
+					"public":  json1,
+					"cluster": json2,
+				},
+			}
+			objMeta := metav1.ObjectMeta{}
+			err := ApplyMultus(net, &objMeta)
+			assert.NoError(t, err)
+			// non-osd pods should only get public networks
+			assert.Equal(t, "["+json1+"]", objMeta.Annotations["k8s.v1.cni.cncf.io/networks"])
+		})
 
-func TestNetwork_ApplyMultusJSON(t *testing.T) {
-	net := rookv1.NetworkSpec{
-		Provider: "multus",
-		Selectors: map[string]string{
-			"server": `{"name": "macvlan", "interface": "net1"}`,
-			"broker": `{"name": "macvlan", "interface": "net2"}`,
-		},
-	}
+		t.Run("for an osd pod", func(t *testing.T) {
+			net := rookv1.NetworkSpec{
+				Provider: "multus",
+				Selectors: map[string]string{
+					"server": json1,
+					"broker": json2,
+				},
+			}
+			objMeta := metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": "rook-ceph-osd",
+				},
+			}
+			err := ApplyMultus(net, &objMeta)
+			assert.NoError(t, err)
+			assert.Equal(t, "["+json1+", "+json2+"]", objMeta.Annotations["k8s.v1.cni.cncf.io/networks"])
+		})
 
-	objMeta := metav1.ObjectMeta{}
-	objMeta.Labels = map[string]string{
-		"app": "rook-ceph-osd",
-	}
-	err := ApplyMultus(net, &objMeta)
-	assert.NoError(t, err)
+		t.Run("for an osd pod (reverse ordering)", func(t *testing.T) {
+			net := rookv1.NetworkSpec{
+				Provider: "multus",
+				Selectors: map[string]string{
+					"server": json2,
+					"broker": json1,
+				},
+			}
+			objMeta := metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": "rook-ceph-osd",
+				},
+			}
+			err := ApplyMultus(net, &objMeta)
+			assert.NoError(t, err)
+			// should not change the order of output
+			assert.Equal(t, "["+json1+", "+json2+"]", objMeta.Annotations["k8s.v1.cni.cncf.io/networks"])
+		})
+	})
 
-	assert.Contains(t, objMeta.Annotations, "k8s.v1.cni.cncf.io/networks")
-	assert.Contains(t, objMeta.Annotations["k8s.v1.cni.cncf.io/networks"], `{"name": "macvlan", "interface": "net1"}`)
-	assert.Contains(t, objMeta.Annotations["k8s.v1.cni.cncf.io/networks"], `{"name": "macvlan", "interface": "net2"}`)
-}
+	t.Run("mixed format (error)", func(t *testing.T) {
+		net := rookv1.NetworkSpec{
+			Provider: "multus",
+			Selectors: map[string]string{
+				"server": `{"name": "macvlan", "interface": "net1"}`,
+				"broker": `macvlan@net2`,
+			},
+		}
 
-func TestNetwork_ApplyMultusMixedError(t *testing.T) {
-	net := rookv1.NetworkSpec{
-		Provider: "multus",
-		Selectors: map[string]string{
-			"server": `{"name": "macvlan", "interface": "net1"}`,
-			"broker": `macvlan@net2`,
-		},
-	}
+		objMeta := metav1.ObjectMeta{}
+		err := ApplyMultus(net, &objMeta)
 
-	objMeta := metav1.ObjectMeta{}
-	err := ApplyMultus(net, &objMeta)
-
-	assert.Error(t, err)
+		assert.Error(t, err)
+	})
 }
 
 func TestGetNetworkAttachmentConfig(t *testing.T) {


### PR DESCRIPTION
In pkg/operator/k8sutil/network.go:ApplyMultus(), sort the string
annotations before applying them so that Rook will avoid the situation
where a Deployment or Pod will need updated repeatedly even when no
Multus network configuration has changed.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1970503

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
