### PR TITLE
Bug 1974204: Evict a mon if colocated with another mon

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -40,6 +40,8 @@ var (
 
 	retriesBeforeNodeDrainFailover = 1
 	timeZero                       = time.Duration(0)
+	// Check whether mons are on the same node once per operator restart since it's a rare scheduling condition
+	needToCheckMonsOnSameNode = true
 )
 
 // HealthChecker aggregates the mon/cluster info needed to check the health of the monitors
@@ -208,7 +210,6 @@ func (c *Cluster) checkHealth() error {
 		if time.Since(c.monTimeoutList[mon.Name]) <= MonOutTimeout {
 			timeToFailover := int(MonOutTimeout.Seconds() - time.Since(c.monTimeoutList[mon.Name]).Seconds())
 			logger.Warningf("mon %q not found in quorum, waiting for timeout (%d seconds left) before failover", mon.Name, timeToFailover)
-
 			continue
 		}
 
@@ -257,10 +258,18 @@ func (c *Cluster) checkHealth() error {
 		}
 	}
 
-	// remove any pending/not needed mon canary deployment if everything is ok
 	if allMonsInQuorum && len(quorumStatus.MonMap.Mons) == desiredMonCount {
+		// remove any pending/not needed mon canary deployment if everything is ok
 		logger.Debug("mon cluster is healthy, removing any existing canary deployment")
 		c.removeCanaryDeployments()
+
+		// Check whether two healthy mons are on the same node when they should not be.
+		// This should be a rare event to find them on the same node, so we just need to check
+		// once per operator restart.
+		if needToCheckMonsOnSameNode {
+			needToCheckMonsOnSameNode = false
+			return c.evictMonIfMultipleOnSameNode()
+		}
 	}
 
 	return nil
@@ -593,4 +602,45 @@ func (c *Cluster) addOrRemoveExternalMonitor(status cephclient.MonStatusResponse
 
 	logger.Debugf("ClusterInfo.Monitors is %+v", c.ClusterInfo.Monitors)
 	return changed, nil
+}
+
+func (c *Cluster) evictMonIfMultipleOnSameNode() error {
+	if c.spec.Mon.AllowMultiplePerNode {
+		logger.Debug("skipping check for multiple mons on same node since multiple mons are allowed")
+		return nil
+	}
+
+	logger.Info("checking if multiple mons are on the same node")
+
+	// Get all the mon pods
+	label := fmt.Sprintf("app=%s", AppName)
+	pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return errors.Wrap(err, "failed to list mon pods")
+	}
+
+	nodesToMons := map[string]string{}
+	for _, pod := range pods.Items {
+		logger.Debugf("analyzing mon pod %q on node %q", pod.Name, pod.Spec.NodeName)
+		if _, ok := pod.Labels["mon_canary"]; ok {
+			logger.Debugf("skipping mon canary pod %q", pod.Name)
+			continue
+		}
+		if pod.Spec.NodeName == "" {
+			logger.Warningf("mon %q is not assigned to a node", pod.Name)
+			continue
+		}
+		monName := pod.Labels["mon"]
+		previousMonName, ok := nodesToMons[pod.Spec.NodeName]
+		if !ok {
+			// remember this node is taken by this mon
+			nodesToMons[pod.Spec.NodeName] = monName
+			continue
+		}
+
+		logger.Warningf("Both mons %q and %q are on node %q. Evicting mon %q", monName, previousMonName, pod.Spec.NodeName, monName)
+		return c.failoverMon(monName)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In a production cluster we never should have two mons running on the same node. However, if two mons have ended up on the same node, whether from a bug or some other unintentional event, the operator will evict one of them and failover to a new mon. This only applies when allowMultiplePerNode is false.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1974204

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
