### PR TITLE
Bug 1964467: ceph: do not require rgw 'instances' spec

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -5565,7 +5565,7 @@ spec:
                     instances:
                       description: The number of pods in the rgw replicaset.
                       format: int32
-                      minimum: 1
+                      nullable: true
                       type: integer
                     labels:
                       additionalProperties:
@@ -6043,8 +6043,6 @@ spec:
                       description: The name of the secret that stores the ssl certificate for secure rgw connections
                       nullable: true
                       type: string
-                  required:
-                    - instances
                   type: object
                 healthCheck:
                   description: The rgw Bucket healthchecks and liveness probe

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -5560,7 +5560,7 @@ spec:
                     instances:
                       description: The number of pods in the rgw replicaset.
                       format: int32
-                      minimum: 1
+                      nullable: true
                       type: integer
                     labels:
                       additionalProperties:
@@ -6038,8 +6038,6 @@ spec:
                       description: The name of the secret that stores the ssl certificate for secure rgw connections
                       nullable: true
                       type: string
-                  required:
-                    - instances
                   type: object
                 healthCheck:
                   description: The rgw Bucket healthchecks and liveness probe

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1078,8 +1078,9 @@ type GatewaySpec struct {
 	SecurePort int32 `json:"securePort,omitempty"`
 
 	// The number of pods in the rgw replicaset.
-	// +kubebuilder:validation:Minimum=1
-	Instances int32 `json:"instances"`
+	// +nullable
+	// +optional
+	Instances int32 `json:"instances,omitempty"`
 
 	// The name of the secret that stores the ssl certificate for secure rgw connections
 	// +nullable


### PR DESCRIPTION
When the cluster is external we don't have any instances of rgw running
so let's not have this as a required field in the spec.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit e25e0e81039d00752b17c98d9a1e86d5f3956436)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
