### PR TITLE
Bug 1981849: ceph: add missing ceph cluster spec

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -634,6 +634,16 @@ func (p *Provisioner) setAdminOpsAPIClient() error {
 		return errors.Wrapf(err, "failed to get ceph object store %q", p.objectStoreName)
 	}
 
+	cephCluster, err := p.getCephCluster()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get ceph cluster in namespace %q", p.clusterInfo.Namespace)
+	}
+	if cephCluster == nil {
+		return errors.Errorf("failed to read ceph cluster in namespace %q, it's nil", p.clusterInfo.Namespace)
+	}
+	// Set the Ceph Cluster Spec so that we can fetch the admin ops key properly when multus is enabled
+	p.objectContext.CephClusterSpec = cephCluster.Spec
+
 	// Fetch the object store admin ops user
 	accessKey, secretKey, err := cephObject.GetAdminOPSUserCredentials(p.context, p.clusterInfo, p.objectContext, cephObjectStore)
 	if err != nil {

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -106,6 +106,19 @@ func getService(c kubernetes.Interface, namespace, name string) (*v1.Service, er
 	return svc, nil
 }
 
+func (p *Provisioner) getCephCluster() (*cephv1.CephCluster, error) {
+	cephCluster, err := p.context.RookClientset.CephV1().CephClusters(p.clusterInfo.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list ceph clusters in namespace %q", p.clusterInfo.Namespace)
+	}
+	if len(cephCluster.Items) == 0 {
+		return nil, errors.Errorf("failed to find ceph cluster in namespace %q", p.clusterInfo.Namespace)
+	}
+
+	// This is a bit weak, but there will always be a single cluster per namespace anyway
+	return &cephCluster.Items[0], err
+}
+
 func randomString(n int) string {
 
 	var letterRunes = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
The lib-bucket-provisioner was missing the cephCluster spec so the check
in RunAdminCommandNoMultisite would fail.
This is similar to ad54ed8aacf6d6e7fc49657568ebc051a0f2ae76 just a
different place.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 1fd76a11685f950425bdfc1db43da37f5aeda58b)
(cherry picked from commit 641988b0dff5db2a1b84bd40b8d740819ac506bf)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
