### PR TITLE
Bug 1966139: [release-4.7] ceph: add osd slow ops alert

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -175,6 +175,18 @@ spec:
       for: 1m
       labels:
         severity: critical
+    - alert: CephOSDSlowOps
+      annotations:
+        description: '{{ $value }} Ceph OSD requests are taking too long to process.
+          Please check ceph status to find out the cause.'
+        message: OSD requests are taking too long to process.
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        ceph_healthcheck_slow_ops > 0
+      for: 30s
+      labels:
+        severity: warning
     - alert: CephDataRecoveryTakingTooLong
       annotations:
         description: Data recovery has been active for too long. Contact Support.


### PR DESCRIPTION
This commit adds an alert that notifies the users about OSD
requests taking too long to process.

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>
(cherry picked from commit f84cbb47fe40089dad29b7455e16a03453a854fb)

