### PR TITLE
Bug 1977020: Add targetSizeRatio to the v1 schema

### DIFF
--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -613,6 +613,8 @@ spec:
                             minimum: 0
                             maximum: 10
                             type: integer
+                          targetSizeRatio:
+                            type: number
                           requireSafeReplicaSize:
                             type: boolean
                           replicasPerFailureDomain:
@@ -854,6 +856,8 @@ spec:
                       properties:
                         size:
                           type: integer
+                        targetSizeRatio:
+                          type: number
                         requireSafeReplicaSize:
                           type: boolean
                         replicasPerFailureDomain:
@@ -1083,6 +1087,8 @@ spec:
                       properties:
                         size:
                           type: integer
+                        targetSizeRatio:
+                          type: number
                         requireSafeReplicaSize:
                           type: boolean
                     erasureCoded:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the targetSizeRatio missing from the v1 schema, the setting is
being ignored on the filesystem and object store CRs, thus preventing
the pg autoscaler from behaving as expected in OCS 4.7.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1977020

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
