### PR TITLE
Bug 1989759: Refuse to failover the arbiter mon on stretch clusters

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -227,7 +227,10 @@ func (c *Cluster) checkHealth() error {
 		retriesBeforeNodeDrainFailover = 1
 
 		logger.Warningf("mon %q NOT found in quorum and timeout exceeded, mon will be failed over", mon.Name)
-		c.failMon(len(quorumStatus.MonMap.Mons), desiredMonCount, mon.Name)
+		if !c.failMon(len(quorumStatus.MonMap.Mons), desiredMonCount, mon.Name) {
+			// The failover was skipped, so we continue to see if another mon needs to failover
+			continue
+		}
 
 		// only deal with one unhealthy mon per health check
 		return nil
@@ -276,13 +279,24 @@ func (c *Cluster) checkHealth() error {
 }
 
 // failMon compares the monCount against desiredMonCount
-func (c *Cluster) failMon(monCount, desiredMonCount int, name string) {
+// Returns whether the failover request was attempted. If false,
+// the operator should check for other mons to failover.
+func (c *Cluster) failMon(monCount, desiredMonCount int, name string) bool {
 	if monCount > desiredMonCount {
 		// no need to create a new mon since we have an extra
 		if err := c.removeMon(name); err != nil {
 			logger.Errorf("failed to remove mon %q. %v", name, err)
 		}
 	} else {
+		if c.spec.IsStretchCluster() && name == c.arbiterMon {
+			// Ceph does not currently support updating the arbiter mon
+			// or else the mons in the two datacenters will not be aware anymore
+			// of the arbiter mon. Thus, disabling failover until the arbiter
+			// mon can be updated in ceph.
+			logger.Warningf("refusing to failover arbiter mon %q on a stretched cluster", name)
+			return false
+		}
+
 		// prevent any voluntary mon drain while failing over
 		if err := c.blockMonDrain(types.NamespacedName{Name: monPDBName, Namespace: c.Namespace}); err != nil {
 			logger.Errorf("failed to block mon drain. %v", err)
@@ -298,6 +312,7 @@ func (c *Cluster) failMon(monCount, desiredMonCount int, name string) {
 			logger.Errorf("failed to allow mon drain. %v", err)
 		}
 	}
+	return true
 }
 
 func (c *Cluster) removeOrphanMonResources() {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Stretch clusters in Ceph do not yet support failing over the arbiter mon, so we now disable the arbiter mon from failing over. Soon Ceph will support the arbiter mon failover and we will reenable this failover feature.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1989759

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
