### PR TITLE
Bug 1994588: ceph: fix panic when recreating the csidriver object

### DIFF
--- a/pkg/operator/ceph/csi/betav1csidriver.go
+++ b/pkg/operator/ceph/csi/betav1csidriver.go
@@ -90,18 +90,16 @@ func (d beta1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kuber
 }
 
 func (d beta1CsiDriver) reCreateCSIDriverInfo(ctx context.Context) error {
-	csiDriver := d.csiDriver
-	csiClient := d.csiClient
-	err := csiClient.Delete(ctx, csiDriver.Name, metav1.DeleteOptions{})
+	err := d.csiClient.Delete(ctx, d.csiDriver.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete CSIDriver object for driver %q", csiDriver.Name)
+		return errors.Wrapf(err, "failed to delete CSIDriver object for driver %q", d.csiDriver.Name)
 	}
-	logger.Infof("CSIDriver object deleted for driver %q", csiDriver.Name)
-	_, err = csiClient.Create(ctx, csiDriver, metav1.CreateOptions{})
+	logger.Infof("CSIDriver object deleted for driver %q", d.csiDriver.Name)
+	_, err = d.csiClient.Create(ctx, d.csiDriver, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to recreate CSIDriver object for driver %q", csiDriver.Name)
+		return errors.Wrapf(err, "failed to recreate CSIDriver object for driver %q", d.csiDriver.Name)
 	}
-	logger.Infof("CSIDriver object recreated for driver %q", csiDriver.Name)
+	logger.Infof("CSIDriver object recreated for driver %q", d.csiDriver.Name)
 	return nil
 }
 

--- a/pkg/operator/ceph/csi/betav1csidriver.go
+++ b/pkg/operator/ceph/csi/betav1csidriver.go
@@ -72,6 +72,8 @@ func (d beta1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kuber
 	// As FSGroupPolicy field is immutable, should be set only during create time.
 	// if the request is to change the FSGroupPolicy, we are deleting the CSIDriver object and creating it.
 	if driver.Spec.FSGroupPolicy != nil && csiDriver.Spec.FSGroupPolicy != nil && *driver.Spec.FSGroupPolicy != *csiDriver.Spec.FSGroupPolicy {
+		d.csiClient = csidrivers
+		d.csiDriver = csiDriver
 		return d.reCreateCSIDriverInfo(ctx)
 	}
 

--- a/pkg/operator/ceph/csi/csidriver.go
+++ b/pkg/operator/ceph/csi/csidriver.go
@@ -72,6 +72,8 @@ func (d v1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kubernet
 	// As FSGroupPolicy field is immutable, should be set only during create time.
 	// if the request is to change the FSGroupPolicy, we are deleting the CSIDriver object and creating it.
 	if driver.Spec.FSGroupPolicy != nil && csiDriver.Spec.FSGroupPolicy != nil && *driver.Spec.FSGroupPolicy != *csiDriver.Spec.FSGroupPolicy {
+		d.csiClient = csidrivers
+		d.csiDriver = csiDriver
 		return d.reCreateCSIDriverInfo(ctx)
 	}
 

--- a/pkg/operator/ceph/csi/csidriver.go
+++ b/pkg/operator/ceph/csi/csidriver.go
@@ -90,18 +90,16 @@ func (d v1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kubernet
 }
 
 func (d v1CsiDriver) reCreateCSIDriverInfo(ctx context.Context) error {
-	csiDriver := d.csiDriver
-	csiClient := d.csiClient
-	err := csiClient.Delete(ctx, csiDriver.Name, metav1.DeleteOptions{})
+	err := d.csiClient.Delete(ctx, d.csiDriver.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete CSIDriver object for driver %q", csiDriver.Name)
+		return errors.Wrapf(err, "failed to delete CSIDriver object for driver %q", d.csiDriver.Name)
 	}
-	logger.Infof("CSIDriver object deleted for driver %q", csiDriver.Name)
-	_, err = csiClient.Create(ctx, d.csiDriver, metav1.CreateOptions{})
+	logger.Infof("CSIDriver object deleted for driver %q", d.csiDriver.Name)
+	_, err = d.csiClient.Create(ctx, d.csiDriver, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to recreate CSIDriver object for driver %q", csiDriver.Name)
+		return errors.Wrapf(err, "failed to recreate CSIDriver object for driver %q", d.csiDriver.Name)
 	}
-	logger.Infof("CSIDriver object recreated for driver %q", csiDriver.Name)
+	logger.Infof("CSIDriver object recreated for driver %q", d.csiDriver.Name)
 	return nil
 }
 

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -423,7 +423,6 @@ func startDrivers(clientset kubernetes.Interface, rookclientset rookclient.Inter
 			return errors.Wrap(err, "failed to load rbd plugin service template")
 		}
 		rbdService.Namespace = namespace
-		logger.Info("successfully started CSI Ceph RBD")
 	}
 	if EnableCephFS {
 		cephfsPlugin, err = templateToDaemonSet("cephfsplugin", CephFSPluginTemplatePath, tp)
@@ -441,7 +440,6 @@ func startDrivers(clientset kubernetes.Interface, rookclientset rookclient.Inter
 			return errors.Wrap(err, "failed to load cephfs plugin service template")
 		}
 		cephfsService.Namespace = namespace
-		logger.Info("successfully started CSI CephFS driver")
 	}
 
 	// get provisioner toleration and node affinity
@@ -495,6 +493,7 @@ func startDrivers(clientset kubernetes.Interface, rookclientset rookclient.Inter
 			return errors.Wrapf(err, "failed to start rbd provisioner deployment: %+v", rbdProvisionerDeployment)
 		}
 		k8sutil.AddRookVersionLabelToDeployment(rbdProvisionerDeployment)
+		logger.Info("successfully started CSI Ceph RBD driver")
 	}
 
 	if rbdService != nil {
@@ -555,6 +554,7 @@ func startDrivers(clientset kubernetes.Interface, rookclientset rookclient.Inter
 			return errors.Wrapf(err, "failed to start cephfs provisioner deployment: %+v", cephfsProvisionerDeployment)
 		}
 		k8sutil.AddRookVersionLabelToDeployment(cephfsProvisionerDeployment)
+		logger.Info("successfully started CSI CephFS driver")
 	}
 	if cephfsService != nil {
 		err = ownerInfo.SetControllerReference(cephfsService)


### PR DESCRIPTION
**Description of your changes:**

This PR fixes the below items

* fix panic in reCreateCSIDriverInfo
   Initialize the client and the csidriver object before calling the reCreateCSIDriverInfo function.
* Reuse defined csiDriver object
   reuse already defined csiDriver object instead of referring to the method receiver
* fix logging of csidriver
   log the successful message about starting CSIDriver after creating the daemonset and deployment objects.

Signed-off-by: Madhu Rajanna madhupr007@gmail.com

Note: the issue was reported at slack https://rook-io.slack.com/archives/CK9CF5H2R/p1629776387282600

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
