### PR TITLE
Bug 1990031: Add timeout in mgr init container

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -169,7 +169,8 @@ func (c *Cluster) makeSetServerAddrInitContainer(mgrConfig *mgrConfig, mgrModule
 	//  L: config-key set       mgr/<mod>/server_addr $(ROOK_CEPH_<MOD>_SERVER_ADDR)
 	//  M: config     set mgr.a mgr/<mod>/server_addr $(ROOK_CEPH_<MOD>_SERVER_ADDR)
 	//  N: config     set mgr.a mgr/<mod>/server_addr $(ROOK_CEPH_<MOD>_SERVER_ADDR) --force
-	cfgSetArgs := []string{"config", "set"}
+	cfgSetArgs := controller.AdminFlags(c.clusterInfo)
+	cfgSetArgs = append(cfgSetArgs, []string{"config", "set"}...)
 	cfgSetArgs = append(cfgSetArgs, fmt.Sprintf("mgr.%s", mgrConfig.DaemonID))
 	cfgPath := fmt.Sprintf("mgr/%s/%s/server_addr", mgrModule, mgrConfig.DaemonID)
 	cfgSetArgs = append(cfgSetArgs, cfgPath, controller.ContainerEnvVarReference(podIPEnvVar))
@@ -177,15 +178,10 @@ func (c *Cluster) makeSetServerAddrInitContainer(mgrConfig *mgrConfig, mgrModule
 	cfgSetArgs = append(cfgSetArgs, "--verbose")
 
 	container := v1.Container{
-		Name: "init-set-" + strings.ToLower(mgrModule) + "-server-addr",
-		Command: []string{
-			"ceph",
-		},
-		Args: append(
-			controller.AdminFlags(c.clusterInfo),
-			cfgSetArgs...,
-		),
-		Image: c.spec.CephVersion.Image,
+		Name:    "init-set-" + strings.ToLower(mgrModule) + "-server-addr",
+		Command: []string{"timeout"},
+		Args:    append([]string{"30s", "ceph"}, cfgSetArgs...),
+		Image:   c.spec.CephVersion.Image,
 		VolumeMounts: append(
 			controller.DaemonVolumeMounts(mgrConfig.DataPathMap, mgrConfig.ResourceName),
 			keyring.VolumeMount().Admin(),


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mgr init containers run a ceph command that may get stuck if the mon quorum is down. The liveness probe is not in effect during the init containers, thus the mgr pod may stay hung indefinitely when this happens. To ensure the mgr does not hang, we add a bash timeout to the ceph command so it will restart and try again in case mon quorum is restored.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1990031

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
